### PR TITLE
fix compilation errors, OSX 10.6-10.9

### DIFF
--- a/konsole-qml-plugin/src/utmpmac.h
+++ b/konsole-qml-plugin/src/utmpmac.h
@@ -1,5 +1,13 @@
 #if defined (__APPLE__)
-# include <utmp.h>
+#include <utmp.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 
 struct utmp *getutent();
 struct utmp *getutid( struct utmp * );


### PR DESCRIPTION
- add missing headers
- see issue https://github.com/Swordifish90/cool-old-term/issues/12
