### PR TITLE
Fix NetBSD case.

### DIFF
--- a/konsole-qml-plugin/src/kpty.cpp
+++ b/konsole-qml-plugin/src/kpty.cpp
@@ -25,9 +25,12 @@
 #include "kpty_p.h"
 
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #define HAVE_LOGIN
 #define HAVE_LIBUTIL_H
+#elif defined(__NetBSD__)
+#define HAVE_LOGIN
+#define HAVE_UTIL_H
 #endif
 
 #ifdef __sgi


### PR DESCRIPTION
NetBSD provides util.h, not libutil.
