### PR TITLE
Update and rename cool-old-term.spec to cool-retro-term.spec

### DIFF
--- a/packaging/rpm/cool-retro-term.spec
+++ b/packaging/rpm/cool-retro-term.spec
@@ -18,7 +18,7 @@
 
 Name:       cool-retro-term
 Summary:    Cool Retro Terminal
-Version:    0.9.20140905
+Version:    0.9
 Release:    0%{?dist}
 Group:      System/X11/Terminals
 License:    GPLv3


### PR DESCRIPTION
Ported the spec file to CRT's new, way nicer build system.

PS: Many thanks to Glen Oakley goakley123@gmail.com and Doug Newgard <scimmia at archlinux dot info> whose workarounds were used previously.
