### PR TITLE
adds compiled files to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ Makefile*
 # Ubuntu SDk
 *.excludes
 *.json
+
+# Excludes compiled files
+imports
+cool-retro-term


### PR DESCRIPTION
It's annoying to see the uncommitted files in git. These files shouldn't be committed anyway, they're compiled files. So, I added them to the gitignore.
