### PR TITLE
add missing dependencies to Debian manifest

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,5 +1,11 @@
+cool-retro-term (0.9-2) UNRELEASED; urgency=medium
+
+  * Adding missing dependencies
+
+ -- Jeka Der <jekader@gmail.com>  Sun, 12 Oct 2014 18:00:00 +0200
+
 cool-retro-term (0.9-1) UNRELEASED; urgency=medium
 
-  * Initial release. (Closes: #XXXXXX)
+  * Initial release.
 
  -- Jeka Der <jekader@gmail.com>  Fri, 10 Oct 2014 19:58:29 +0200

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -10,7 +10,8 @@ Build-Depends: debhelper (>= 9),qmlscene,
 
 Package: cool-retro-term
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Replaces: cool-old-term
+Depends: qml-module-qtquick-controls, qml-module-qtgraphicaleffects, qml-module-qtquick-dialogs, qml-module-qtquick-localstorage, qml-module-qtquick-window2, ${shlibs:Depends}, ${misc:Depends}
 Description: terminal emulator which mimics old screens
  cool-retro-term is a terminal emulator which mimics the look and feel
  of the old cathode tube screens. It has been designed to be eye-candy,


### PR DESCRIPTION
Continuing work on Debian packaging. Today I installed the package on a "clean" machine and noticed some dependencies were not identified during the build. Added them manually to the control file.
