### PR TITLE
Use window title from session. Fixes #167

### DIFF
--- a/app/qml/PreprocessedTerminal.qml
+++ b/app/qml/PreprocessedTerminal.qml
@@ -33,6 +33,8 @@ Item{
     property real dright: frame.item.displacementRight
     property real dbottom: frame.item.displacementBottom
 
+    property alias title: ksession.title
+
     anchors.leftMargin: dleft
     anchors.rightMargin: dright
     anchors.topMargin: dtop

--- a/app/qml/TerminalContainer.qml
+++ b/app/qml/TerminalContainer.qml
@@ -1,6 +1,8 @@
 import QtQuick 2.2
 
 Item{
+    property alias title: terminal.title
+
     Item{
         id: scalableContent
         width: parent.width * shadersettings.window_scaling

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -42,7 +42,7 @@ ApplicationWindow{
                 : shadersettings.showMenubar ? defaultMenuBar : null
 
     color: "#00000000"
-    title: qsTr("cool-retro-term")
+    title: terminalContainer.title || qsTr("cool-retro-term")
 
     Action {
         id: showMenubarAction
@@ -113,6 +113,7 @@ ApplicationWindow{
         enableTimer: terminalWindow.visible
     }
     TerminalContainer{
+        id: terminalContainer
         anchors.fill: parent
     }
     SettingsWindow{

--- a/konsole-qml-plugin/src/ksession.cpp
+++ b/konsole-qml-plugin/src/ksession.cpp
@@ -35,6 +35,7 @@ KSession::KSession(QObject *parent) :
     QObject(parent), m_session(createSession("KSession"))
 {
     connect(m_session, SIGNAL(finished()), this, SLOT(sessionFinished()));
+    connect(m_session, SIGNAL(titleChanged()), this, SIGNAL(titleChanged()));
 }
 
 KSession::~KSession()
@@ -238,4 +239,7 @@ QString KSession::keyBindings()
     return m_session->keyBindings();
 }
 
-
+QString KSession::getTitle()
+{
+    return m_session->userTitle();
+}

--- a/konsole-qml-plugin/src/ksession.h
+++ b/konsole-qml-plugin/src/ksession.h
@@ -35,6 +35,7 @@ class KSession : public QObject
     Q_OBJECT
     Q_PROPERTY(QString  kbScheme  READ  getKeyBindings WRITE setKeyBindings NOTIFY changedKeyBindings)
     Q_PROPERTY(QString  initialWorkingDirectory READ getInitialWorkingDirectory WRITE setInitialWorkingDirectory)
+    Q_PROPERTY(QString  title READ getTitle NOTIFY titleChanged)
 
 public:
     KSession(QObject *parent = 0);
@@ -84,6 +85,8 @@ public:
     //! Return current key bindings
     QString keyBindings();
 
+    QString getTitle();
+
 signals:
     void finished();
     void copyAvailable(bool);
@@ -95,6 +98,7 @@ signals:
 
     void changedKeyBindings(QString kb);
 
+    void titleChanged();
 
 public slots:
     /*! Set named key binding for given widget


### PR DESCRIPTION
Adds path for title from Session to the ApplicationWindow and uses it for window title.
