### PR TITLE
Fix: added missing default precision directives in fragment shaders

### DIFF
--- a/app/qml/PreprocessedTerminal.qml
+++ b/app/qml/PreprocessedTerminal.qml
@@ -312,6 +312,7 @@ Item{
             blending: false
 
             fragmentShader:
+                "precision highp float;" +
                 "uniform lowp float qt_Opacity;" +
                 "uniform lowp sampler2D txt_source;" +
 

--- a/app/qml/ShaderTerminal.qml
+++ b/app/qml/ShaderTerminal.qml
@@ -151,6 +151,8 @@ ShaderEffect {
         }"
 
     fragmentShader: "
+        precision highp float;
+
         uniform sampler2D source;
         uniform highp float qt_Opacity;
         uniform highp float time;

--- a/app/qml/frames/utils/TerminalFrame.qml
+++ b/app/qml/frames/utils/TerminalFrame.qml
@@ -120,6 +120,8 @@ Item{
         blending: true
 
         fragmentShader: "
+            precision highp float;
+
             uniform highp sampler2D normals;
             uniform highp sampler2D source;
             uniform lowp float screenCurvature;
@@ -181,6 +183,8 @@ Item{
             blending: true
 
             fragmentShader: "
+                precision highp float;
+
                 uniform sampler2D lightMask;
                 uniform sampler2D reflectionSource;
                 uniform lowp float diffuseComponent;


### PR DESCRIPTION
Term launched without rendering (all #ff00ff pink) and the glsl compiler was complaining about
```
qml: *** Fragment shader ***
0:7(53): error: no precision specified this scope for type `vec3'
0:7(38): error: no precision specified this scope for type `float'
0:9(16): error: no precision specified this scope for type `vec2'
0:9(43): error: no precision specified this scope for type `vec3'
0:9(94): error: no precision specified this scope for type `vec3'
0:9(173): error: no precision specified this scope for type `vec3'
```
probably because Qt defaults to OpenGL ES on my system, where precision needs to be specified on all types. Might be good to add #version directives to shaders to avoid glsl version ambiguity.