### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ to install precompiled from community repository.
 Gentoo users can now install the first release "1.0" from a 3rd-party repository preferably via layman:
 
     USE="subversion git" emerge app-portage/layman
-    wget --no-check-certificate https://www.gerczei.eu/files/gerczei.xml -O /etc/layman/overlays/gerczei.xml
+    wget https://www.gerczei.eu/files/gerczei.xml -O /etc/layman/overlays/gerczei.xml
     layman -f -a qt -a gerczei # those who've added the repo already should sync instead via 'layman -s gerczei'
     ACCEPT_KEYWORDS="~*" emerge =x11-terms/cool-retro-term-1.0.0-r1::gerczei
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Gentoo users can now install the first release "1.0" from a 3rd-party repository
     USE="subversion git" emerge app-portage/layman
     wget --no-check-certificate https://www.gerczei.eu/files/gerczei.xml -O /etc/layman/overlays/gerczei.xml
     layman -f -a qt -a gerczei # those who've added the repo already should sync instead via 'layman -s gerczei'
-    ACCEPT_KEYWORDS="~*" emerge =x11-terms/cool-retro-term-1.0.0::gerczei
+    ACCEPT_KEYWORDS="~*" emerge =x11-terms/cool-retro-term-1.0.0-r1::gerczei
 
-The live ebuild (version 9999) tracking the bleeding-edge WIP codebase also remains available.
+The live ebuild (version 9999-r1) tracking the bleeding-edge WIP codebase also remains available.
 
 A word of warning: USE flags and keywords are to be added to portage's configuration files and every emerge operation should be executed with '-p' (short option for --pretend) appended to the command line first as per best practice!
 


### PR DESCRIPTION
I've switched to a new certificate thanks to the "Let's Encrypt!" initiative. Owing to this change the HTTPS connection to my overlay no longer needs to be force-fed.