### PR TITLE
Add custom command support

### DIFF
--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -97,6 +97,8 @@ QtObject{
 
     signal terminalFontChanged(string fontSource, int pixelSize, int lineSpacing, real screenScaling, real fontWidth)
 
+    signal initializedSettings()
+
     property Loader fontManager: Loader{
         states: [
             State { when: rasterization == no_rasterization
@@ -463,6 +465,8 @@ QtObject{
             fullscreen = true;
             showMenubar = false;
         }
+
+        initializedSettings();
     }
     Component.onDestruction: {
         storeSettings();

--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -51,6 +51,9 @@ QtObject{
 
     // PROFILE SETTINGS ///////////////////////////////////////////////////////
 
+    property bool useCustomCommand: false
+    property string customCommand: ""
+
     property string _backgroundColor: "#000000"
     property string _fontColor: "#ff8100"
     property string saturatedColor: Utils.mix(Utils.strToColor("#FFFFFF"), Utils.strToColor(_fontColor), saturationColor * 0.5)
@@ -240,7 +243,9 @@ QtObject{
             ambientLight: ambientLight,
             windowOpacity: windowOpacity,
             fontName: fontNames[rasterization],
-            fontWidth: fontWidth
+            fontWidth: fontWidth,
+            useCustomCommand: useCustomCommand,
+            customCommand: customCommand
         }
         return settings;
     }
@@ -328,6 +333,9 @@ QtObject{
         fontNames[rasterization] = settings.fontName !== undefined ? settings.fontName : fontNames[rasterization];
         fontWidth = settings.fontWidth !== undefined ? settings.fontWidth : fontWidth;
 
+        useCustomCommand = settings.useCustomCommand !== undefined ? settings.useCustomCommand : useCustomCommand
+        customCommand = settings.customCommand !== undefined ? settings.customCommand : customCommand
+
         handleFontChanged();
     }
 
@@ -377,47 +385,47 @@ QtObject{
     property ListModel profilesList: ListModel{
         ListElement{
             text: "Default Amber"
-            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0.65,"brightness":0.5,"flickering":0.1,"contrast":0.85,"fontName":"TERMINUS_SCALED","fontColor":"#ff8100","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0.2,"horizontalSync":0.16,"jitter":0.18,"burnIn":0.4,"staticNoise":0.1,"rasterization":0,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0}'
+            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0.65,"brightness":0.5,"flickering":0.1,"contrast":0.85,"fontName":"TERMINUS_SCALED","fontColor":"#ff8100","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0.2,"horizontalSync":0.16,"jitter":0.18,"burnIn":0.4,"staticNoise":0.1,"rasterization":0,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0,"useCustomCommand":false,"customCommand":""}'
             builtin: true
         }
         ListElement{
             text: "Default Green"
-            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0.4,"brightness":0.5,"flickering":0.1,"contrast":0.85,"fontName":"TERMINUS_SCALED","fontColor":"#0ccc68","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0.2,"horizontalSync":0.16,"jitter":0.18,"burnIn":0.45,"staticNoise":0.1,"rasterization":0,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0}'
+            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0.4,"brightness":0.5,"flickering":0.1,"contrast":0.85,"fontName":"TERMINUS_SCALED","fontColor":"#0ccc68","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0.2,"horizontalSync":0.16,"jitter":0.18,"burnIn":0.45,"staticNoise":0.1,"rasterization":0,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0,"useCustomCommand":false,"customCommand":""}'
             builtin: true
         }
         ListElement{
             text: "Default Scanlines"
-            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0.4,"brightness":0.5,"flickering":0.1,"contrast":0.85,"fontName":"COMMODORE_PET","fontColor":"#00ff5b","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0.2,"horizontalSync":0.14,"jitter":0.11,"burnIn":0.4,"staticNoise":0.05,"rasterization":1,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0}'
+            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0.4,"brightness":0.5,"flickering":0.1,"contrast":0.85,"fontName":"COMMODORE_PET","fontColor":"#00ff5b","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0.2,"horizontalSync":0.14,"jitter":0.11,"burnIn":0.4,"staticNoise":0.05,"rasterization":1,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0,"useCustomCommand":false,"customCommand":""}'
             builtin: true
         }
         ListElement{
             text: "Default Pixelated"
-            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0,"brightness":0.5,"flickering":0.2,"contrast":0.85,"fontName":"COMMODORE_PET","fontColor":"#ffffff","frameName":"ROUGH_BLACK_FRAME","glowingLine":0.2,"horizontalSync":0.2,"jitter":0,"burnIn":0.45,"staticNoise":0.19,"rasterization":2,"screenCurvature":0.05,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0}'
+            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0,"brightness":0.5,"flickering":0.2,"contrast":0.85,"fontName":"COMMODORE_PET","fontColor":"#ffffff","frameName":"ROUGH_BLACK_FRAME","glowingLine":0.2,"horizontalSync":0.2,"jitter":0,"burnIn":0.45,"staticNoise":0.19,"rasterization":2,"screenCurvature":0.05,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0,"useCustomCommand":false,"customCommand":""}'
             builtin: true
         }
         ListElement{
             text: "Apple ]["
-            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0.5,"brightness":0.5,"flickering":0.2,"contrast":0.85,"fontName":"APPLE_II","fontColor":"#2fff91","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0.22,"horizontalSync":0.16,"jitter":0.1,"burnIn":0.65,"staticNoise":0.08,"rasterization":1,"screenCurvature":0.18,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0}'
+            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0.5,"brightness":0.5,"flickering":0.2,"contrast":0.85,"fontName":"APPLE_II","fontColor":"#2fff91","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0.22,"horizontalSync":0.16,"jitter":0.1,"burnIn":0.65,"staticNoise":0.08,"rasterization":1,"screenCurvature":0.18,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0,"useCustomCommand":false,"customCommand":""}'
             builtin: true
         }
         ListElement{
             text: "Vintage"
-            obj_string: '{"ambientLight":0.5,"backgroundColor":"#000000","bloom":0.4,"brightness":0.5,"flickering":0.9,"contrast":0.80,"fontName":"COMMODORE_PET","fontColor":"#00ff3e","frameName":"ROUGH_BLACK_FRAME","glowingLine":0.3,"horizontalSync":0.42,"jitter":0.4,"burnIn":0.75,"staticNoise":0.2,"rasterization":1,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0}'
+            obj_string: '{"ambientLight":0.5,"backgroundColor":"#000000","bloom":0.4,"brightness":0.5,"flickering":0.9,"contrast":0.80,"fontName":"COMMODORE_PET","fontColor":"#00ff3e","frameName":"ROUGH_BLACK_FRAME","glowingLine":0.3,"horizontalSync":0.42,"jitter":0.4,"burnIn":0.75,"staticNoise":0.2,"rasterization":1,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0,"useCustomCommand":false,"customCommand":""}'
             builtin: true
         }
         ListElement{
             text: "IBM Dos"
-            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0.4,"brightness":0.5,"flickering":0.07,"contrast":0.85,"fontName":"IBM_DOS","fontColor":"#ffffff","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0.13,"horizontalSync":0,"jitter":0.16,"burnIn":0.3,"staticNoise":0.03,"rasterization":0,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":1,"saturationColor":0,"rbgShift":0.35,"fontWidth":1.0}'
+            obj_string: '{"ambientLight":0.16,"backgroundColor":"#000000","bloom":0.4,"brightness":0.5,"flickering":0.07,"contrast":0.85,"fontName":"IBM_DOS","fontColor":"#ffffff","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0.13,"horizontalSync":0,"jitter":0.16,"burnIn":0.3,"staticNoise":0.03,"rasterization":0,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":1,"saturationColor":0,"rbgShift":0.35,"fontWidth":1.0,"useCustomCommand":false,"customCommand":""}'
             builtin: true
         }
         ListElement{
             text: "IBM 3278"
-            obj_string: '{"ambientLight":0.1,"backgroundColor":"#000000","bloom":0.15,"brightness":0.5,"flickering":0,"contrast":0.85,"fontName":"IBM_3278","fontColor":"#0ccc68","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0,"horizontalSync":0,"jitter":0,"burnIn":0.6,"staticNoise":0,"rasterization":0,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0}'
+            obj_string: '{"ambientLight":0.1,"backgroundColor":"#000000","bloom":0.15,"brightness":0.5,"flickering":0,"contrast":0.85,"fontName":"IBM_3278","fontColor":"#0ccc68","frameName":"SIMPLE_WHITE_FRAME","glowingLine":0,"horizontalSync":0,"jitter":0,"burnIn":0.6,"staticNoise":0,"rasterization":0,"screenCurvature":0.1,"windowOpacity":1,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0,"useCustomCommand":false,"customCommand":""}'
             builtin: true
         }
         ListElement{
             text: "Transparent Green"
-            obj_string: '{"ambientLight":0.2,"backgroundColor":"#000000","bloom":0.45,"brightness":0.5,"flickering":0.20,"contrast":0.85,"fontName":"TERMINUS_SCALED","fontColor":"#0ccc68","frameName":"NO_FRAME","glowingLine":0.16,"horizontalSync":0.1,"jitter":0.20,"burnIn":0.25,"staticNoise":0.20,"rasterization":0,"screenCurvature":0.05,"windowOpacity":0.60,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0}'
+            obj_string: '{"ambientLight":0.2,"backgroundColor":"#000000","bloom":0.45,"brightness":0.5,"flickering":0.20,"contrast":0.85,"fontName":"TERMINUS_SCALED","fontColor":"#0ccc68","frameName":"NO_FRAME","glowingLine":0.16,"horizontalSync":0.1,"jitter":0.20,"burnIn":0.25,"staticNoise":0.20,"rasterization":0,"screenCurvature":0.05,"windowOpacity":0.60,"chromaColor":0,"saturationColor":0,"rbgShift":0,"fontWidth":1.0,"useCustomCommand":false,"customCommand":""}'
             builtin: true
         }
     }

--- a/app/qml/PreprocessedTerminal.qml
+++ b/app/qml/PreprocessedTerminal.qml
@@ -129,13 +129,17 @@ Item{
 
             kterminal.lineSpacing = lineSpacing;
         }
-        Component.onCompleted: {
-            appSettings.terminalFontChanged.connect(handleFontChange);
+        function startSession() {
+            appSettings.initializedSettings.disconnect(startSession);
 
             // Retrieve the variable set in main.cpp if arguments are passed.
             if (defaultCmd) {
                 ksession.setShellProgram(defaultCmd);
                 ksession.setArgs(defaultCmdArgs);
+            } else if (appSettings.useCustomCommand) {
+                var args = Utils.tokenizeCommandLine(appSettings.customCommand);
+                ksession.setShellProgram(args[0]);
+                ksession.setArgs(args.slice(1));
             } else if (!defaultCmd && Qt.platform.os === "osx") {
                 // OSX Requires the following default parameters for auto login.
                 ksession.setArgs(["-i", "-l"]);
@@ -146,6 +150,10 @@ Item{
 
             ksession.startShellProgram();
             forceActiveFocus();
+        }
+        Component.onCompleted: {
+            appSettings.terminalFontChanged.connect(handleFontChange);
+            appSettings.initializedSettings.connect(startSession);
         }
     }
     Component {

--- a/app/qml/SettingsGeneralTab.qml
+++ b/app/qml/SettingsGeneralTab.qml
@@ -171,7 +171,7 @@ Tab{
                     checked: appSettings.useCustomCommand
                     onCheckedChanged: appSettings.useCustomCommand = checked
                 }
-                // workaround for QTBUG-31627 for pre 5.3.0
+                // Workaround for QTBUG-31627 for pre 5.3.0
                 Binding{
                     target: useCustomCommand
                     property: "checked"
@@ -179,10 +179,16 @@ Tab{
                 }
                 TextField{
                     id: customCommand
+                    anchors {left: parent.left; right: parent.right}
                     text: appSettings.customCommand
                     enabled: useCustomCommand.checked
                     onEditingFinished: appSettings.customCommand = text
-                    anchors {left: parent.left; right: parent.right}
+
+                    // Save text even if user forgets to press enter or unfocus
+                    function saveSetting() {
+                        appSettings.customCommand = text;
+                    }
+                    Component.onCompleted: settings_window.closing.connect(saveSetting)
                 }
             }
         }

--- a/app/qml/SettingsGeneralTab.qml
+++ b/app/qml/SettingsGeneralTab.qml
@@ -159,6 +159,34 @@ Tab{
                 }
             }
         }
+
+        GroupBox{
+            anchors {left: parent.left; right: parent.right}
+            title: qsTr("Command")
+            ColumnLayout {
+                anchors.fill: parent
+                CheckBox{
+                    id: useCustomCommand
+                    text: qsTr("Use custom command instead of shell at startup")
+                    checked: appSettings.useCustomCommand
+                    onCheckedChanged: appSettings.useCustomCommand = checked
+                }
+                // workaround for QTBUG-31627 for pre 5.3.0
+                Binding{
+                    target: useCustomCommand
+                    property: "checked"
+                    value: appSettings.useCustomCommand
+                }
+                TextField{
+                    id: customCommand
+                    text: appSettings.customCommand
+                    enabled: useCustomCommand.checked
+                    onEditingFinished: appSettings.customCommand = text
+                    anchors {left: parent.left; right: parent.right}
+                }
+            }
+        }
+
         // DIALOGS ////////////////////////////////////////////////////////////////
         InsertNameDialog{
             id: insertname


### PR DESCRIPTION
Gnome Terminal has a profile-specific setting to run an arbitrary command on startup instead of the default shell. I know CRT has a -e option on the CLI, but I think it'd be more useful to have a dedicated setting bound to each profile.

This PR adds that custom command setting. The setting can be changed in the General tab in the settings menu. Loading/changing the setting will only affect the next term that starts. The -e option still works, and would override the custom command as expected.