### PR TITLE
fix issue #267 - do not use transparent color to avoid z-order issue in Ubuntu 14.04

### DIFF
--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -43,7 +43,7 @@ ApplicationWindow{
         __contentItem.visible: mainMenu.visible
     }
 
-    color: "#00000000"
+    color: "#000000"
     title: terminalContainer.title || qsTr("cool-retro-term")
 
     Action {


### PR DESCRIPTION
Tested only in Ubuntu 14.04. It fixes the reported issue with no visible consequences.