### PR TITLE
Remember window size automatically

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -81,7 +81,12 @@ int main(int argc, char *argv[])
     importPathList.prepend(QCoreApplication::applicationDirPath() + "/../../../qmltermwidget");
     engine.setImportPathList(importPathList);
 
-    engine.load(QUrl("qrc:/main.qml"));
+    engine.load(QUrl(QStringLiteral ("qrc:/main.qml")));
+
+    if (engine.rootObjects().isEmpty()) {
+        qDebug() << "Cannot load QML interface";
+        return EXIT_FAILURE;
+    }
 
     // Quit the application when the engine closes.
     QObject::connect((QObject*) &engine, SIGNAL(quit()), (QObject*) &app, SLOT(quit()));

--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -33,6 +33,11 @@ QtObject{
 
     // GENERAL SETTINGS ///////////////////////////////////////////////////////
 
+    property int x: 100
+    property int y: 100
+    property int width: 1024
+    property int height: 768
+
     property bool fullscreen: false
     property bool showMenubar: true
 
@@ -211,6 +216,10 @@ QtObject{
     function composeSettingsString(){
         var settings = {
             fps: fps,
+            x: x,
+            y: y,
+            width: width,
+            height: height,
             windowScaling: windowScaling,
             showTerminalSize: showTerminalSize,
             fontScaling: fontScaling,
@@ -290,6 +299,11 @@ QtObject{
 
         fps = settings.fps !== undefined ? settings.fps: fps
         windowScaling = settings.windowScaling !== undefined ? settings.windowScaling : windowScaling
+
+        x = settings.x !== undefined ? settings.x : x
+        y = settings.y !== undefined ? settings.y : y
+        width = settings.width !== undefined ? settings.width : width
+        height = settings.height !== undefined ? settings.height : height
 
         fontNames = settings.fontNames !== undefined ? settings.fontNames : fontNames
         fontScaling = settings.fontScaling !== undefined ? settings.fontScaling : fontScaling

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -40,6 +40,8 @@ ApplicationWindow{
     // Save window size automatically
     Settings {
         category: "MainWindow"
+        property alias x: terminalWindow.x
+        property alias y: terminalWindow.y
         property alias width: terminalWindow.width
         property alias height: terminalWindow.height
     }

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -21,7 +21,6 @@
 import QtQuick 2.2
 import QtQuick.Window 2.1
 import QtQuick.Controls 1.1
-import Qt.labs.settings 1.0
 import QtGraphicalEffects 1.0
 
 ApplicationWindow{
@@ -29,22 +28,32 @@ ApplicationWindow{
 
     width: 1024
     height: 768
+
+    // Save window properties automatically
+    onXChanged: appSettings.x = x
+    onYChanged: appSettings.y = y
+    onWidthChanged: appSettings.width = width
+    onHeightChanged: appSettings.height = height
+
+    // Load saved window geometry and show the window
+    Component.onCompleted: {        
+        appSettings.handleFontChanged();
+
+        x = appSettings.x
+        y = appSettings.y
+        width = appSettings.width
+        height = appSettings.height
+
+        visible = true
+    }
+
     minimumWidth: 320
     minimumHeight: 240
 
-    visible: true
+    visible: false
 
     property bool fullscreen: appSettings.fullscreen
     onFullscreenChanged: visibility = (fullscreen ? Window.FullScreen : Window.Windowed)
-
-    // Save window size automatically
-    Settings {
-        category: "MainWindow"
-        property alias x: terminalWindow.x
-        property alias y: terminalWindow.y
-        property alias width: terminalWindow.width
-        property alias height: terminalWindow.height
-    }
 
     //Workaround: Without __contentItem a ugly thin border is visible.
     menuBar: CRTMainMenuBar{
@@ -150,7 +159,6 @@ ApplicationWindow{
             terminalSize: terminalContainer.terminalSize
         }
     }
-    Component.onCompleted: appSettings.handleFontChanged();
     onClosing: {
         // OSX Since we are currently supporting only one window
         // quit the application when it is closed.

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -21,6 +21,7 @@
 import QtQuick 2.2
 import QtQuick.Window 2.1
 import QtQuick.Controls 1.1
+import Qt.labs.settings 1.0
 import QtGraphicalEffects 1.0
 
 ApplicationWindow{
@@ -35,6 +36,13 @@ ApplicationWindow{
 
     property bool fullscreen: appSettings.fullscreen
     onFullscreenChanged: visibility = (fullscreen ? Window.FullScreen : Window.Windowed)
+
+    // Save window size automatically
+    Settings {
+        category: "MainWindow"
+        property alias width: terminalWindow.width
+        property alias height: terminalWindow.height
+    }
 
     //Workaround: Without __contentItem a ugly thin border is visible.
     menuBar: CRTMainMenuBar{


### PR DESCRIPTION
This patch allows the application to save and load window size automatically (issue #91), using the ~~QML Settings Plugins~~ built-in settings module.

I have tested on OS X 10.11, but it should work on any other platform. 