### PR TITLE
update change log for a first upload (sponsoring)

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,11 +1,5 @@
-cool-retro-term (0.9-2) UNRELEASED; urgency=medium
-
-  * Adding missing dependencies
-
- -- Jeka Der <jekader@gmail.com>  Sun, 12 Oct 2014 18:00:00 +0200
-
 cool-retro-term (0.9-1) UNRELEASED; urgency=medium
 
-  * Initial release.
+  * Initial release. (Closes: #758238)
 
  -- Jeka Der <jekader@gmail.com>  Fri, 10 Oct 2014 19:58:29 +0200


### PR DESCRIPTION
how it should be for a first official Debian package.
the number refers to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=758238