### PR TITLE
Add a -T option that sets window title.

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -54,6 +54,7 @@ int main(int argc, char *argv[])
         qDebug() << "  --default-settings  Run cool-retro-term with the default settings";
         qDebug() << "  --workdir <dir>     Change working directory to 'dir'";
         qDebug() << "  -e <cmd>            Command to execute. This option will catch all following arguments, so use it as the last option.";
+        qDebug() << "  -T <title>          Set window title to 'title'.";
         qDebug() << "  --fullscreen        Run cool-retro-term in fullscreen.";
         qDebug() << "  -p|--profile <prof> Run cool-retro-term with the given profile.";
         qDebug() << "  -h|--help           Print this help.";

--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -41,6 +41,8 @@ QtObject{
     property bool fullscreen: false
     property bool showMenubar: true
 
+    property string wintitle: "cool-retro-term"
+
     property real windowOpacity: 1.0
     property real ambientLight: 0.2
     property real contrast: 0.85
@@ -478,6 +480,10 @@ QtObject{
         if (args.indexOf("--fullscreen") !== -1) {
             fullscreen = true;
             showMenubar = false;
+        }
+
+        if (args.indexOf("-T") !== -1) {
+            wintitle = args[args.indexOf("-T") + 1]
         }
 
         initializedSettings();

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -62,8 +62,10 @@ ApplicationWindow{
         __contentItem.visible: mainMenu.visible
     }
 
+    property string wintitle: appSettings.wintitle
+
     color: "#00000000"
-    title: terminalContainer.title || qsTr("cool-retro-term")
+    title: terminalContainer.title || qsTr(appSettings.wintitle)
 
     Action {
         id: showMenubarAction


### PR DESCRIPTION
`cool-retro-term -T myretrosession` sets window name to 'myretrosession'

This is useful especially for people who rely on wmctrl to change windows, now I
can do `wmctrl -a myretrocession` to focus on cool-retro-term.

-T was chosen since it matches classic xterm(1) and other terminal emulators

--

Please have in mind I've never done any QT/Javascript/QML/C++, this code might be full of bad practices.

Having said that, I really need this since I run multiple terminals, each with different name, and switch them on the keyboard with wmctrl.