### PR TITLE
add Debian Stretch to dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Make sure to install these first.
 
 ---
 
-**Debian Jessie**
+**Debian Jessie or Stretch**
 
     sudo apt-get install build-essential qmlscene qt5-qmake qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtgraphicaleffects qml-module-qtquick-dialogs qml-module-qtquick-localstorage qml-module-qtquick-window2
 


### PR DESCRIPTION
I've confirmed that the same instructions for Jessie also work for Stretch