### PR TITLE
Add Debian Stretch build and run dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Make sure to install these first.
 
 ---
 
-**Debian Jessie**
+**Debian Jessie or Stretch**
 
     sudo apt-get install build-essential qmlscene qt5-qmake qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtgraphicaleffects qml-module-qtquick-dialogs qml-module-qtquick-localstorage qml-module-qtquick-window2
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,15 @@ Make sure to install these first.
 
 ---
 
-**Debian Jessie or Stretch**
+**Debian Jessie**
 
     sudo apt-get install build-essential qmlscene qt5-qmake qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtgraphicaleffects qml-module-qtquick-dialogs qml-module-qtquick-localstorage qml-module-qtquick-window2
+
+---
+
+**Debian Stretch**
+
+    sudo apt-get install build-essential qmlscene qt5-qmake qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtgraphicaleffects qml-module-qtquick-dialogs qml-module-qtquick-localstorage qml-module-qtquick-window2 qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel
 
 ---
 


### PR DESCRIPTION
Debian Stretch has the same build requirements as Jessie, but it also needs `qml-module-qt-labs-settings` and `qml-module-qt-labs-folderlistmodel` in order to run cool-retro-term.