### PR TITLE
Refine alt(meta) and ctrl behaviour for emacs on macos

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -36,6 +36,10 @@ int main(int argc, char *argv[])
 #endif
 
     QApplication app(argc, argv);
+    // set application attributes
+    // Has no effects, see https://bugreports.qt.io/browse/QTBUG-51293
+    // app.setAttribute(Qt::AA_MacDontSwapCtrlAndMeta, true);
+
     QQmlApplicationEngine engine;
     FileIO fileIO;
 

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -101,12 +101,12 @@ ApplicationWindow{
     Action{
         id: copyAction
         text: qsTr("Copy")
-        shortcut: Qt.platform.os === "osx" ? StandardKey.Copy : "Ctrl+Shift+C"
+        shortcut: "Ctrl+Shift+C"
     }
     Action{
         id: pasteAction
         text: qsTr("Paste")
-        shortcut: Qt.platform.os === "osx" ? StandardKey.Paste : "Ctrl+Shift+V"
+        shortcut: "Ctrl+Shift+V"
     }
     Action{
         id: zoomIn


### PR DESCRIPTION
Solved 2 problems(if they are) of this terminal while doing emacs on macos

* problem 1:
alt is used as dead key marker on mac.

* problem 2:
qt default for macos:
control -> meta
command -> control

AA_MacDontSwapCtrlAndMeta will not work until stable version of qt reaches 5.11
see [https://bugreports.qt.io/browse/QTBUG-51293](https://bugreports.qt.io/browse/QTBUG-51293)

see the result patched: [https://github.com/picospuch/cool-retro-term/releases/tag/ModKeyFixesForMacos](https://github.com/picospuch/cool-retro-term/releases/tag/ModKeyFixesForMacos)