### PR TITLE
Cool-Retro-Term in a Docker Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ COPY . /app
 WORKDIR /app
 RUN qmake && make
 
-#Add user to /etc/sudoers with sudo permissions
 RUN adduser user --home /home/user
 WORKDIR /app
 RUN chmod +x /app/cool-retro-term

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY . /app
 WORKDIR /app
 RUN qmake && make
 
+#Add user to /etc/sudoers with sudo permissions
 RUN adduser user --home /home/user
 WORKDIR /app
 RUN chmod +x /app/cool-retro-term

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:18.04 as builder
+
+#TODO: Clean up after installation and building
+RUN apt-get update && apt-get install -y  build-essential qml-module-qtgraphicaleffects qml-module-qt-labs-folderlistmodel qml-module-qt-labs-settings qml-module-qtquick-controls qml-module-qtquick-dialogs qmlscene qt5-default qt5-qmake qtdeclarative5-dev qtdeclarative5-localstorage-plugin qtdeclarative5-qtquick2-plugin qtdeclarative5-window-plugin
+
+COPY . /app
+WORKDIR /app
+RUN qmake && make
+
+RUN adduser user --home /home/user
+WORKDIR /app
+RUN chmod +x /app/cool-retro-term
+USER user
+ENTRYPOINT ["./cool-retro-term"]
+
+
+#running: docker run -it --privileged --rm -e DISPLAY=$DISPLAY -e XDG_RUNTIME_DIR=/run/user/1000 -e XAUTHORITY=$XAUTHORITY -v /run/user/1000:/run/user/1000 -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev/dri:/dev/dri retro-term:5

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ or:
 **Arch Linux**
 
     sudo pacman -S qt5-base qt5-declarative qt5-quickcontrols qt5-graphicaleffects
-    
+
 ---
 
 **openSUSE**
@@ -122,16 +122,22 @@ Install dependencies:
     sudo zypper install libqt5-qtbase-devel libqt5-qtdeclarative-devel libqt5-qtquickcontrols libqt5-qtgraphicaleffects
 
 ---
+**Docker**
+Docker users running X-Server can run cool-retro-term in an isolated Docker container using the following command.  Please note that hardware and x-server resources need to be  mounted inside the container in order for the container to have access to hardware acceleration and X-server resources:
+
+```sh
+docker run -it --privileged --rm -e DISPLAY=$DISPLAY -e XDG_RUNTIME_DIR=/run/user/1000 -e XAUTHORITY=$XAUTHORITY -v /run/user/1000:/run/user/1000 -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev/dri:/dev/dri quay.io/aric49/crt:latest
+```
 
 **Anyone else**
 
 Install Qt directly from here http://qt-project.org/downloads . Once done export them in you path (replace "_/opt/Qt5.3.1/5.3/gcc_64/bin_" with your correct folder):
-    
+
     export PATH=/opt/Qt5.3.1/5.3/gcc_64/bin/:$PATH
 ---
 
 ### Compile
-Once you installed all dependencies (Qt is installed and in your path) you need to compile and run the application: 
+Once you installed all dependencies (Qt is installed and in your path) you need to compile and run the application:
 
 ```bash
 # Get it from GitHub
@@ -177,6 +183,16 @@ cd cool-retro-term
 mkdir cool-retro-term.app/Contents/PlugIns
 cp -r qmltermwidget/QMLTermWidget cool-retro-term.app/Contents/PlugIns
 open cool-retro-term.app
+```
+
+## Build Instructions Docker
+Clone the primary repository with the `--recursive` flag, and perform a Docker build.  Docker will automatically compile the code inside a Docker container.  To run the docker container, you need to mount X-Server resources and your video card inside the Docker container so that Docker can initiate the GUI and successfully start cool-retro-term with hardware acceleration:
+
+```sh
+git clone --recursive https://github.com/Swordfish90/cool-retro-term.git
+docker build -t cool-retro-term:1
+docker run -it --privileged --rm -e DISPLAY=$DISPLAY -e XDG_RUNTIME_DIR=/run/user/1000 -e XAUTHORITY=$XAUTHORITY -v /run/user/1000:/run/user/1000 -v /tmp/.X11-unix:/tmp/.X11-unix -v /dev/dri:/dev/dri cool-retro-term:1
+
 ```
 
 ## Donations


### PR DESCRIPTION
As a fan of Cool-Retro-Term, I took the liberty of creating a Docker Container for running cool-retro-term.  This is a pretty straightforward Docker build that follows the instructions outlined in the `README.md` to build and the project.    This creates a more portable environment for quickly running and customizing cool-retro-term for container nerds like myself.

This should also help developers working on this project to quickly test changes and bugs between versions since Docker will maintain tags between builds. These tagged images can be run simultaneously and should help alleviate some of the QT dependency issues. 

Let me know if this is something you'd be interested in adding to your project (or not). I'm open to feedback and look forward to the future of the project. 