### PR TITLE
correct version number output with --version

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
     }
 
     if (args.contains("-v") || args.contains("--version")) {
-        qDebug() << "cool-retro-term 1.0.1";
+        qDebug() << "cool-retro-term 1.1.0";
 	return 0;
     }
 


### PR DESCRIPTION
Looks like this wasn't looked after when the new release came.