### PR TITLE
Add blinking cursor support

### DIFF
--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -59,6 +59,8 @@ QtObject{
     property real burnInQuality: 0.5
     property bool useFastBurnIn: Qt.platform.os === "osx" ? false : true
 
+    property bool blinkingCursor: true
+
     onWindowScalingChanged: handleFontChanged();
 
     // PROFILE SETTINGS ///////////////////////////////////////////////////////
@@ -208,7 +210,8 @@ QtObject{
             burnInQuality: burnInQuality,
             useCustomCommand: useCustomCommand,
             customCommand: customCommand,
-            useFastBurnIn: useFastBurnIn
+            useFastBurnIn: useFastBurnIn,
+            blinkingCursor: blinkingCursor
         }
         return stringify(settings);
     }
@@ -296,6 +299,8 @@ QtObject{
         customCommand = settings.customCommand !== undefined ? settings.customCommand : customCommand
 
         useFastBurnIn = settings.useFastBurnIn !== undefined ? settings.useFastBurnIn : useFastBurnIn;
+
+        blinkingCursor = settings.blinkingCursor !== undefined ? settings.blinkingCursor : blinkingCursor
     }
 
     function loadProfileString(profileString){

--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -59,7 +59,7 @@ QtObject{
     property real burnInQuality: 0.5
     property bool useFastBurnIn: Qt.platform.os === "osx" ? false : true
 
-    property bool blinkingCursor: true
+    property bool blinkingCursor: false
 
     onWindowScalingChanged: handleFontChanged();
 

--- a/app/qml/PreprocessedTerminal.qml
+++ b/app/qml/PreprocessedTerminal.qml
@@ -94,6 +94,7 @@ Item{
         smooth: !appSettings.lowResolutionFont
         enableBold: false
         fullCursorHeight: true
+        blinkingCursor: appSettings.blinkingCursor
 
         session: QMLTermSession {
             id: ksession

--- a/app/qml/SettingsTerminalTab.qml
+++ b/app/qml/SettingsTerminalTab.qml
@@ -115,6 +115,24 @@ Tab{
             }
         }
         GroupBox{
+            title: qsTr("Cursor")
+            Layout.fillWidth: true
+            ColumnLayout {
+                anchors.fill: parent
+                CheckBox{
+                    id: blinkingCursor
+                    text: qsTr("Blinking Cursor")
+                    checked: appSettings.blinkingCursor
+                    onCheckedChanged: appSettings.blinkingCursor = checked
+                }
+                Binding{
+                    target: blinkingCursor
+                    property: "checked"
+                    value: appSettings.blinkingCursor
+                }
+            }
+        }
+        GroupBox{
             title: qsTr("Colors")
             Layout.fillWidth: true
             ColumnLayout{


### PR DESCRIPTION
Adds support for blinking cursor.

The `qmltermwidget` submodule is updated to expose a corresponding property (see https://github.com/Swordfish90/qmltermwidget/pull/25).

The blinking cursor option is enabled by default and can be tweaked in the _terminal_ settings tab.