### PR TITLE
Add installation instructions using Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ cp -r qmltermwidget/QMLTermWidget cool-retro-term.app/Contents/PlugIns
 open cool-retro-term.app
 ```
 
+**Homebrew**
+
+```sh
+brew cask install cool-retro-term
+```
+
 ## Donations
 I made this project in my spare time because I love what I'm doing. If you are enjoying it and you want to buy me a beer click [here](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=flscogna%40gmail%2ecom&lc=IT&item_name=Filippo%20Scognamiglio&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donate_LG%2egif%3aNonHosted).
 


### PR DESCRIPTION
I was not aware there was a [Homebrew cask](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/cool-retro-term.rb) for this
project, which simplifies installation on macOS. This commit adds
documentation for installing the app via Homebrew.