### PR TITLE
Update Readme.md to include directions to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ It uses the QML port of qtermwidget (Konsole) developed by me: https://github.co
 
 This terminal emulator works under Linux and macOS and requires Qt 5.2 or higher.
 
+Settings such as colors, fonts, and effects can be accessed via context menu.
+
 ## Screenshots
 ![Image](<https://i.imgur.com/TNumkDn.png>)
 ![Image](<https://i.imgur.com/hfjWOM4.png>)


### PR DESCRIPTION
Several users of OS's without titlebars or window decor have expressed confusion at how one change's their theme (in this case, via the context menu). Mentioning how to access the menu in the Readme will make the settings more accessible and prevent any future confusion. It might be more appropriate to create a "Use" heading exploring features such as Performance settings, but for the sake of brevity, I've just inserted a mention at the end of the description, before more OS-specific install instructions. There is likely a better place for the mention further down.