### PR TITLE
Update Readme.md to ref official Gentoo Repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,9 @@ or use:
 
 to install precompiled from community repository.
 
-**Gentoo** users can now install the fourth release "1.1.1" from a 3rd-party repository preferably via layman:
+**Gentoo** users can now install the fourth release "1.1.1" from the official Gentoo reopistory:
 
-    USE="git" emerge app-portage/layman
-    wget https://www.gerczei.eu/files/gerczei.xml -O /etc/layman/overlays/gerczei.xml
-    layman -f -a qt -a gerczei # those who've added the repo before 27/08/17 should remove, update and add it again as its source has changed
-    ACCEPT_KEYWORDS="~*" emerge =x11-terms/cool-retro-term-1.1.1::gerczei
+    emerge x11-terms/cool-retro-term
 
 The live ebuild (version 9999-r1) tracking the bleeding-edge WIP codebase also remains available.
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ to install precompiled from community repository.
 
     emerge x11-terms/cool-retro-term
 
-The live ebuild (version 9999-r1) tracking the bleeding-edge WIP codebase also remains available.
-
 A word of warning: USE flags and keywords are to be added to portage's configuration files and every emerge operation should be executed with '-p' (short option for --pretend) appended to the command line first as per best practice!
 
 Users of **Ubuntu 14.04 LTS (Trusty) up to 15.10 (Wily)** can use [this PPA](https://launchpad.net/~bugs-launchpad-net-falkensweb).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ or use:
 
 to install precompiled from community repository.
 
-**Gentoo** users can now install the fourth release "1.1.1" from the official Gentoo reopistory:
+**Gentoo** users can now install the fourth release "1.1.1" from the official Gentoo repository:
 
     emerge x11-terms/cool-retro-term
 


### PR DESCRIPTION
As per https://github.com/Swordfish90/cool-retro-term/pull/566 and https://github.com/Swordfish90/cool-retro-term/issues/76 Gentoo users must install from the official repos. The ebuild included in the mentioned overlay will not build at this time as it uses an outdated, unsupported EAPI, and will not be updated, having been superseded by an official package. User confusion and frustration may result if the Readme is not updated. https://github.com/Swordfish90/cool-retro-term/pull/566 suggests removing the section entirely, which would also work, but I figure we give directions for other distros ¯\\_(ツ)_/¯

One could argue that I should have left the ACCEPT_KEYWORDS env var, but any Gentoo user should be familiar enough with Portage to resolve any possible package keyword issues, or should take this as an opportunity to look it up and set it permanently. I would not recommend installing  packages with temporary env use flags unless resolving conflicting use flags while updating or installing a oneshot package, which is not the case here. The paragraph about safe emerge practices remains and sufficiently hints the user towards resolving any keyword issues themselves that I felt the env var no longer needed set temporarily on initial installation. Doing so would likely prevent any nieve users who might have benefited from bypassing keyword issues from receiving updates in the future.