### PR TITLE
Adds qml-module-qmltermwidget as a dependency for debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Make sure to install these first.
 
 **Debian Jessie and above**
 
-    sudo apt install build-essential qmlscene qt5-qmake qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtgraphicaleffects qml-module-qtquick-dialogs qml-module-qtquick-localstorage qml-module-qtquick-window2 qml-module-qt-labs-settings qml-module-qt-labs-folderlistmodel
+    sudo apt install build-essential qmlscene qt5-qmake qt5-default qtdeclarative5-dev qml-module-qtquick-controls qml-module-qtgraphicaleffects qml-module-qtquick-dialogs qml-module-qtquick-localstorage qml-module-qtquick-window2 qml-module-qt-labs-settings qml-module-qt-labs-folderlistmode qml-module-qmltermwidget
 
 ---
 


### PR DESCRIPTION
When building on Debian I found I needed to install the package `qml-module-qmltermwidget`, which was missing from the dependencies list.