### PR TITLE
Update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ open cool-retro-term.app
 **Homebrew**
 
 ```sh
-brew cask install cool-retro-term
+brew install --cask cool-retro-term
 ```
 
 ## Donations


### PR DESCRIPTION
Apparently, they changed the `brew` install command for casks. Got this error message:
> Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.

Change to newly suggested cask install style.