### PR TITLE
Fix rendering on non HiDPI screens

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -97,8 +97,6 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("fileIO", &fileIO);
     engine.rootContext()->setContextProperty("monospaceSystemFonts", monospaceFontManager.retrieveMonospaceFonts());
 
-    engine.rootContext()->setContextProperty("devicePixelRatio", app.devicePixelRatio());
-
     // Manage import paths for Linux and OSX.
     QStringList importPathList = engine.importPathList();
     importPathList.prepend(QCoreApplication::applicationDirPath() + "/qmltermwidget");

--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -42,6 +42,7 @@ QtObject{
     property int y: 100
     property int width: 1024
     property int height: 768
+    property real pixelRatio: 1.0
 
     property bool fullscreen: false
     property bool showMenubar: Qt.platform.os === "osx" ? true : false

--- a/app/qml/Fonts.qml
+++ b/app/qml/Fonts.qml
@@ -28,7 +28,7 @@ QtObject{
     property bool lowResolutionFont: _font.lowResolutionFont
 
     property int pixelSize: lowResolutionFont
-                                 ? _font.pixelSize
+                                 ? _font.pixelSize * 2.0 / appSettings.pixelRatio
                                  : _font.pixelSize * scaling
 
     property int lineSpacing: lowResolutionFont
@@ -36,7 +36,7 @@ QtObject{
                                   : pixelSize * _font.lineSpacing
 
     property real screenScaling: lowResolutionFont
-                                     ? _font.baseScaling * scaling
+                                     ? _font.baseScaling * scaling / 2.0 / appSettings.pixelRatio
                                      : 1.0
 
     property real defaultFontWidth: fontlist.get(selectedFontIndex).fontWidth

--- a/app/qml/PreprocessedTerminal.qml
+++ b/app/qml/PreprocessedTerminal.qml
@@ -71,7 +71,7 @@ Item{
     QMLTermWidget {
         id: kterminal
 
-        property int textureResolutionScale: appSettings.lowResolutionFont ? devicePixelRatio : 1
+        property int textureResolutionScale: appSettings.lowResolutionFont ? appSettings.pixelRatio : 1
         property int margin: appSettings.margin / screenScaling
         property int totalWidth: Math.floor(parent.width / (screenScaling * fontWidth))
         property int totalHeight: Math.floor(parent.height / screenScaling)
@@ -81,8 +81,8 @@ Item{
 
         textureSize: Qt.size(width / textureResolutionScale, height / textureResolutionScale)
 
-        width: ensureMultiple(rawWidth, devicePixelRatio)
-        height: ensureMultiple(rawHeight, devicePixelRatio)
+        width: ensureMultiple(rawWidth, appSettings.pixelRatio)
+        height: ensureMultiple(rawHeight, appSettings.pixelRatio)
 
         /** Ensure size is a multiple of factor. This is needed for pixel perfect scaling on highdpi screens. */
         function ensureMultiple(size, factor) {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -30,8 +30,14 @@ ApplicationWindow{
     height: 768
 
     // Save window properties automatically
-    onXChanged: appSettings.x = x
-    onYChanged: appSettings.y = y
+    onXChanged: {
+        appSettings.x = x
+        appSettings.pixelRatio = Window.devicePixelRatio
+    }
+    onYChanged: {
+        appSettings.y = y
+        appSettings.pixelRatio = Window.devicePixelRatio
+    }
     onWidthChanged: appSettings.width = width
     onHeightChanged: appSettings.height = height
 


### PR DESCRIPTION
If you have more than one monitor and you drag cool-retro-term from a HiDPI (Retina) screen to a lower resolution screen, the rendering would be at an unreadable low resolution.

Resolves #541 