### PR TITLE
Scanline fixes

### DIFF
--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -94,6 +94,7 @@ QtObject{
     property real flickering: 0.1
 
     property real rbgShift: 0.0
+    property real scanlineBlur: 0.0
 
     property real _margin: 0.5
     property real margin: Utils.lint(1.0, 20.0, _margin)
@@ -232,6 +233,7 @@ QtObject{
             rasterization: rasterization,
             jitter: jitter,
             rbgShift: rbgShift,
+            scanlineBlur: scanlineBlur,
             brightness: brightness,
             contrast: contrast,
             ambientLight: ambientLight,
@@ -325,6 +327,7 @@ QtObject{
         jitter = settings.jitter !== undefined ? settings.jitter : jitter;
 
         rbgShift = settings.rbgShift !== undefined ? settings.rbgShift : rbgShift;
+        scanlineBlur = settings.scanlineBlur !== undefined ? settings.scanlineBlur : rbgShift;
 
         ambientLight = settings.ambientLight !== undefined ? settings.ambientLight : ambientLight;
         contrast = settings.contrast !== undefined ? settings.contrast : contrast;
@@ -402,9 +405,38 @@ QtObject{
                   "jitter": 0.1997,
                   "rasterization": 0,
                   "rbgShift": 0,
+                  "scanlineBlur": 0,
                   "saturationColor": 0.2483,
                   "screenCurvature": 0.3,
                   "staticNoise": 0.1198,
+                  "windowOpacity": 1,
+                  "margin": 0.5
+                }'
+            builtin: true
+        }
+        ListElement{
+            text: "Amber Scanlines"
+            obj_string: '{
+                  "ambientLight": 0.2,
+                  "backgroundColor": "#000000",
+                  "bloom": 0.32,
+                  "brightness": 1,
+                  "burnIn": 0.30,
+                  "chromaColor": 1,
+                  "contrast": 0.75,
+                  "flickering": 0.04,
+                  "fontColor": "#ff8100",
+                  "fontName": "TERMINUS_SCALED",
+                  "fontWidth": 1,
+                  "glowingLine": 0,
+                  "horizontalSync": 0,
+                  "jitter": 0.03,
+                  "rasterization": 1,
+                  "rbgShift": 0,
+                  "scanlineBlur": 0.05,
+                  "saturationColor": 1,
+                  "screenCurvature": 0.05,
+                  "staticNoise": 0.05,
                   "windowOpacity": 1,
                   "margin": 0.5
                 }'
@@ -430,6 +462,7 @@ QtObject{
                   "jitter": 0.1997,
                   "rasterization": 0,
                   "rbgShift": 0,
+                  "scanlineBlur": 0,
                   "saturationColor": 0.0,
                   "screenCurvature": 0.3,
                   "staticNoise": 0.1198,
@@ -458,6 +491,7 @@ QtObject{
                   "jitter": 0.11,
                   "rasterization": 1,
                   "rbgShift": 0,
+                  "scanlineBlur": 0.05,
                   "saturationColor": 0.5,
                   "screenCurvature": 0.3,
                   "staticNoise": 0.15,
@@ -486,6 +520,7 @@ QtObject{
                   "jitter": 0,
                   "rasterization": 2,
                   "rbgShift": 0,
+                  "scanlineBlur": 0,
                   "saturationColor": 0,
                   "screenCurvature": 0,
                   "staticNoise": 0.15,
@@ -514,6 +549,7 @@ QtObject{
                   "jitter": 0.1,
                   "rasterization": 1,
                   "rbgShift": 0,
+                  "scanlineBlur": 0,
                   "saturationColor": 0,
                   "screenCurvature": 0.5,
                   "staticNoise": 0.099,
@@ -542,6 +578,7 @@ QtObject{
                   "jitter": 0.4,
                   "rasterization": 1,
                   "rbgShift": 0.2969,
+                  "scanlineBlur": 0,
                   "saturationColor": 0,
                   "screenCurvature": 0.5,
                   "staticNoise": 0.2969,
@@ -570,6 +607,7 @@ QtObject{
                   "jitter": 0.1545,
                   "rasterization": 0,
                   "rbgShift": 0.3524,
+                  "scanlineBlur": 0,
                   "saturationColor": 0,
                   "screenCurvature": 0.4,
                   "staticNoise": 0.0503,
@@ -598,6 +636,7 @@ QtObject{
                   "jitter": 0,
                   "rasterization": 0,
                   "rbgShift": 0,
+                  "scanlineBlur": 0,
                   "saturationColor": 0,
                   "screenCurvature": 0.2,
                   "staticNoise": 0,
@@ -626,6 +665,7 @@ QtObject{
                   "jitter": 0.099,
                   "rasterization": 0,
                   "rbgShift": 0,
+                  "scanlineBlur": 0,
                   "saturationColor": 0.4983,
                   "screenCurvature": 0,
                   "staticNoise": 0.0955,

--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -420,7 +420,7 @@ QtObject{
                   "ambientLight": 0.2,
                   "backgroundColor": "#000000",
                   "bloom": 0.32,
-                  "brightness": 1,
+                  "brightness": 0.85,
                   "burnIn": 0.30,
                   "chromaColor": 1,
                   "contrast": 0.75,

--- a/app/qml/SettingsEffectsTab.qml
+++ b/app/qml/SettingsEffectsTab.qml
@@ -85,6 +85,11 @@ Tab{
                     onNewValue: appSettings.rbgShift = newValue;
                     value: appSettings.rbgShift;
                 }
+                CheckableSlider{
+                    name: qsTr("Scanline Blur")
+                    onNewValue: appSettings.scanlineBlur = newValue;
+                    value: appSettings.scanlineBlur;
+                }
             }
         }
     }

--- a/app/qml/ShaderTerminal.qml
+++ b/app/qml/ShaderTerminal.qml
@@ -378,6 +378,7 @@ Item {
          property real chromaColor: appSettings.chromaColor;
 
          property real rbgShift: (appSettings.rbgShift / width) * appSettings.totalFontScaling // TODO FILIPPO width here is wrong.
+         property real scanlineBlur: (appSettings.scanlineBlur / width) * appSettings.totalFontScaling
 
          property int rasterization: appSettings.rasterization
 
@@ -423,6 +424,9 @@ Item {
              (rbgShift !== 0 ? "
                  uniform lowp float rbgShift;" : "") +
 
+             (scanlineBlur !== 0 ? "
+                 uniform lowp float scanlineBlur;" : "") +
+
              (ambientLight !== 0 ? "
                  uniform lowp float ambientLight;" : "") +
 
@@ -432,15 +436,15 @@ Item {
                 (appSettings.rasterization != appSettings.no_rasterization ?
                     "float val = 0.0;
                      vec2 rasterizationCoords = fract(coords * virtual_resolution);
-                     val += smoothstep(0.0, 0.5, rasterizationCoords.y);
-                     val -= smoothstep(0.5, 1.0, rasterizationCoords.y);
-                     result *= mix(0.5, 1.0, val);" : "") +
+                     val += smoothstep(0.1, 0.5, rasterizationCoords.y);
+                     val -= smoothstep(0.5, 0.9, rasterizationCoords.y);
+                     result *= mix(0.3, 1.0, val);" : "") +
 
                 (appSettings.rasterization == appSettings.pixel_rasterization ?
                     "val = 0.0;
                      val += smoothstep(0.0, 0.5, rasterizationCoords.x);
                      val -= smoothstep(0.5, 1.0, rasterizationCoords.x);
-                     result *= mix(0.5, 1.0, val);" : "") + "
+                     result *= mix(0.1, 1.0, val);" : "") + "
 
                 return result;
              }
@@ -488,6 +492,19 @@ Item {
                      txt_color.r = leftColor.r * 0.10 + rightColor.r * 0.30 + txt_color.r * 0.60;
                      txt_color.g = leftColor.g * 0.20 + rightColor.g * 0.20 + txt_color.g * 0.60;
                      txt_color.b = leftColor.b * 0.30 + rightColor.b * 0.10 + txt_color.b * 0.60;
+                 " : "") +
+
+                 (scanlineBlur !== 0 ? "
+                     vec2 scanlineBlur_displacement = vec2(12.0, 0.0) * scanlineBlur;
+                     vec3 scanlineBlur_rightColor = texture2D(source, txt_coords + scanlineBlur_displacement).rgb;
+                     vec3 scanlineBlur_leftColor = texture2D(source, txt_coords - scanlineBlur_displacement).rgb;
+                     vec3 scanlineBlur_rightColor2 = texture2D(source, txt_coords + scanlineBlur_displacement + scanlineBlur_displacement).rgb;
+                     vec3 scanlineBlur_leftColor2 = texture2D(source, txt_coords - scanlineBlur_displacement - scanlineBlur_displacement).rgb;
+                     vec3 scanlineBlur_rightColor3 = texture2D(source, txt_coords + scanlineBlur_displacement + scanlineBlur_displacement + scanlineBlur_displacement).rgb;
+                     vec3 scanlineBlur_leftColor3 = texture2D(source, txt_coords - scanlineBlur_displacement - scanlineBlur_displacement - scanlineBlur_displacement).rgb;
+                     txt_color.r = scanlineBlur_leftColor3.r * 0.05 + scanlineBlur_leftColor2.r * 0.1 + scanlineBlur_leftColor.r * 0.20 + txt_color.r * 0.30 + scanlineBlur_rightColor.r * 0.20 + scanlineBlur_rightColor2.r * 0.1 + scanlineBlur_rightColor3.r * 0.05;
+                     txt_color.g = scanlineBlur_leftColor3.g * 0.05 + scanlineBlur_leftColor2.g * 0.1 + scanlineBlur_leftColor.g * 0.20 + txt_color.g * 0.30 + scanlineBlur_rightColor.g * 0.20 + scanlineBlur_rightColor2.g * 0.1 + scanlineBlur_rightColor3.g * 0.05;
+                     txt_color.b = scanlineBlur_leftColor3.b * 0.05 + scanlineBlur_leftColor2.b * 0.1 + scanlineBlur_leftColor.b * 0.20 + txt_color.b * 0.30 + scanlineBlur_rightColor.b * 0.20 + scanlineBlur_rightColor2.b * 0.1 + scanlineBlur_rightColor3.b * 0.05;
                  " : "") +
 
                   "txt_color *= getScanlineIntensity(txt_coords);" +


### PR DESCRIPTION
This resolves two issues with scanline rendering : 
 * Burn-in does not respect/include rasterization (scanlines or pixels)
 * Scanlines end abruptly 

Example of burn-in issue: 

![Screenshot from 2021-04-27 12 11 06](https://user-images.githubusercontent.com/7475484/116329541-2f43c880-a791-11eb-8331-82d296dfdaf2.png)

Example of both issues fixed:
![Screenshot from 2021-04-27 17 47 49](https://user-images.githubusercontent.com/7475484/116329759-a2e5d580-a791-11eb-85a0-422515c3ca13.png)

Example of "scanlines end abruptly":

![Screenshot from 2021-04-27 16 49 37](https://user-images.githubusercontent.com/7475484/116329656-729e3700-a791-11eb-93b7-8fd47c7837ec.png)

Similar screenshot with horizontal-only scanline blurring enabled (5%):

![Screenshot from 2021-04-27 16 49 53](https://user-images.githubusercontent.com/7475484/116329709-89dd2480-a791-11eb-96bd-1a8cabf0c5a0.png)

I've never used QML before, and I know nothing about shaders, so apologies for the brute-force solutions.





