### PR TITLE
Fixed Homebrew invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ eopkg it cool-retro-term
 
 **macOS** users can grab the latest dmg from the [release page](https://github.com/Swordfish90/cool-retro-term/releases) or install via Homebrew:
 ```
-brew cask install cool-retro-term
+brew install cool-retro-term
 ```
 
 **FreeBSD** users can install cool-retro-term with `pkg`:


### PR DESCRIPTION
Existing command results in `Error: Unknown command: cask`