### PR TITLE
update brew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ open cool-retro-term.app
 **Homebrew**
 
 ```sh
-brew cask install cool-retro-term
+brew install cool-retro-term --cask
 ```
 
 ## Donations

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ eopkg it cool-retro-term
 
 **macOS** users can grab the latest dmg from the [release page](https://github.com/Swordfish90/cool-retro-term/releases) or install via Homebrew:
 ```
-brew cask install cool-retro-term
+brew install cool-retro-term --cask
 ```
 
 **FreeBSD** users can install cool-retro-term with `pkg`:


### PR DESCRIPTION
I tried this command, but failed.
(M1 Mac mini2020, OS: Big Sur ver11.4, 16GB)

```
➜  brew cask install cool-retro-term
Error: Unknown command: cask

➜  brew install cool-retro-term --cask
...
🍺  cool-retro-term was successfully installed!
```


https://github.com/ansible-collections/community.general/issues/1524
> brew cask commands were deprecated on 2020-12-01 with the release of Homebrew 2.6.0. Starting then, all brew cask commands succeeded but displayed a warning informing users that the command would soon be disabled. The message also provides the appropriate replacement.

`brew cask` seems be deprecated.