### PR TITLE
Add short form of --profile to match documentation

### DIFF
--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -721,7 +721,7 @@ QtObject {
 
         loadCustomProfiles()
 
-        var profileArgPosition = args.indexOf("--profile")
+        var profileArgPosition = args.indexOf(/-p|--profile/)
         if (profileArgPosition !== -1) {
             var profileIndex = getProfileIndexByName(
                         args[profileArgPosition + 1])


### PR DESCRIPTION
https://github.com/Swordfish90/cool-retro-term/blob/74ae511f923a7c42274086f9b9959e2292d74ddc/app/main.cpp#L58

The usage documents `-p` as a short form of `--profile` but it's not currently implemented.