### PR TITLE
Fix background in settings window

### DIFF
--- a/app/qml/SettingsWindow.qml
+++ b/app/qml/SettingsWindow.qml
@@ -30,6 +30,7 @@ Window {
     width: 640
     height: 640
 
+    color: palette.window
     property int tabmargins: 15
 
     Item {


### PR DESCRIPTION
Fixes #428, fixes #612, fixes #689

Settings window text is unreadable in dark themes because background is white on any theme. This PR fixes the problem. Works with both dark and light themes.

After fix:
![](https://user-images.githubusercontent.com/2903496/170832302-323d9cc6-0e3f-40a6-9716-c6fc9d207df3.png)

![](https://user-images.githubusercontent.com/2903496/170832335-35513f47-fd55-43ab-aad4-be3f40b0cff0.png)
