### PR TITLE
Hide visible scrolling in background staticNoise

### DIFF
--- a/app/qml/ShaderTerminal.qml
+++ b/app/qml/ShaderTerminal.qml
@@ -243,6 +243,17 @@ Item {
              "  return outColor;
              }" +
 
+             //pseudo-random vector
+             //https://stackoverflow.com/a/10625698
+             "float random( vec2 p )
+             {
+                 vec2 K1 = vec2(
+                     23.14069263277926, // e^pi (Gelfond's constant)
+                     2.665144142690225 // 2^sqrt(2) (Gelfond-Schneider constant)
+                 );
+                 return fract( cos( dot(p,K1) ) * 12345.6789 );
+             }" +
+
              "void main() {" +
                  "vec2 cc = vec2(0.5) - qt_TexCoord0;" +
                  "float distance = length(cc);" +
@@ -281,7 +292,11 @@ Item {
                  : "") +
 
                  (jitter !== 0 || staticNoise !== 0 ?
-                     "vec4 noiseTexel = texture2D(noiseSource, scaleNoiseSize * coords + vec2(fract(time / 51.0), fract(time / 237.0)));"
+                 "vec4 noiseTexel = texture2D(
+                     noiseSource, scaleNoiseSize * coords
+                     + vec2(0.0, random(vec2(fract(time / 237.0), 822.9582)))
+                     + vec2(fract(time / 31.0), fract(time / 177.0))
+                 );"
                  : "") +
 
                  (jitter !== 0 ? "


### PR DESCRIPTION
The current background staticNoise is generated by scrolling a noise texture. However, I find that the vertical component of the scrolling is visible, most clearly with large window sizes on high-resolution displays. To me, this distracts from the illusion of static noise.

This PR pseudo-randomizes the vertical position of the staticNoise texel and adds that to the pre-existing scrolling of noise texture (both horizontal and vertical; faster in vertical direction). I've found that produces the best balance of hiding visible scrolling while preserving the smoothness of the previous animation. (The pseudo-random function applied to the time variable seems to produce jerky outputs if used on its own, but they aren't visible when scrolling is also applied.)

The static noise still isn't perfect on large windows with this PR applied (mostly due to the fixed 512x512 texture), but the obvious scrolling artifact is removed.