### PR TITLE
Deobfuscate screenshot URLs

### DIFF
--- a/packaging/appdata/cool-retro-term.appdata.xml
+++ b/packaging/appdata/cool-retro-term.appdata.xml
@@ -16,11 +16,11 @@
   <screenshots>
     <screenshot type="default">
       <caption>Default amber look</caption>
-      <image width="1022" height="791">https://camo.githubusercontent.com/2443e662e95733ba6ae331f391f6ec036d1ee7fd/687474703a2f2f692e696d6775722e636f6d2f4e5566766e6c752e706e67</image>
+      <image width="1022" height="791">https://i.imgur.com/NUfvnlu.png</image>
     </screenshot>
     <screenshot>
       <caption>Apple II look</caption>
-      <image width="1024" height="796">https://camo.githubusercontent.com/44a19842d532555c7b02bf6b4b4684add9edf18c/687474703a2f2f692e696d6775722e636f6d2f4d4d6d4d3648742e706e67</image>
+      <image width="1024" height="796">https://i.imgur.com/MMmM6Ht.png</image>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
Unless Imgur-hosted URLs are specifically blacklisted by whatever software or service processes AppData XML, there's no good reason to use GitHub's proxified URLs over the originals.

(The last pathname component of `camo.githubusercontent.com` URLs is a hex representation of the original URL string, which is how I managed to recover them).

~~~console
$ url='https://camo.githubusercontent.com/2443e662e95733ba6ae331f391f6ec036d1ee7fd/687474703a2f2f692e696d6775722e636f6d2f4e5566766e6c752e706e67'
$ printf '%s' "${url##*/}" | xxd -p -r
~~~