### PR TITLE
Change text from IBM Dos to IBM DOS

### DIFF
--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -613,7 +613,7 @@ QtObject {
             builtin: true
         }
         ListElement {
-            text: "IBM Dos"
+            text: "IBM DOS"
             obj_string: '{
                 "ambientLight": 0.151,
                 "backgroundColor": "#000000",


### PR DESCRIPTION
Generally, DOS has its own meaning and itself is an acronym for Disk Operating System. This PR changes the text from `IBM Dos` to `IBM DOS`.