### PR TITLE
Keybinds for Opacity, Contrast and Brightness

### DIFF
--- a/app/qml/TerminalContainer.qml
+++ b/app/qml/TerminalContainer.qml
@@ -29,7 +29,8 @@ ShaderTerminal {
     property real devicePixelRatio: terminalWindow.screen.devicePixelRatio
 
     id: mainShader
-    opacity: appSettings.windowOpacity * 0.3 + 0.7
+
+    opacity: appSettings.windowOpacity + 0.001
 
     source: terminal.mainSource
     burnInEffect: terminal.burnInEffect

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -163,6 +163,22 @@ ApplicationWindow {
         }
     }
     Action {
+        id: brighter
+        text: qsTr("Brighter.")
+        shortcut: "Alt+Up"
+        onTriggered: {
+          appSettings.brightness += appSettings.brightness < (1 - keybindStep) ? keybindStep : 0
+        }
+    }
+    Action {
+        id: darker
+        text: qsTr("Darker.")
+        shortcut: "Alt+Down"
+        onTriggered: {
+          appSettings.brightness -= appSettings.brightness > keybindStep ? keybindStep : 0
+        }
+    }
+    Action {
         id: showAboutAction
         text: qsTr("About")
         onTriggered: {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -29,6 +29,8 @@ ApplicationWindow {
     width: 1024
     height: 768
 
+    property real keybindStep: 0.005
+
     // Save window properties automatically
     onXChanged: appSettings.x = x
     onYChanged: appSettings.y = y
@@ -127,6 +129,22 @@ ApplicationWindow {
         text: qsTr("Zoom Out")
         shortcut: "Ctrl+-"
         onTriggered: appSettings.decrementScaling()
+    }
+    Action {
+        id: lessOpaque
+        text: qsTr("Make less opaque.")
+        shortcut: "Ctrl+Shift+Up"
+        onTriggered: {
+          appSettings.windowOpacity -= appSettings.windowOpacity > keybindStep ? keybindStep : 0
+        }
+    }
+    Action {
+        id: moreOpaque
+        text: qsTr("Make more opaque.")
+        shortcut: "Ctrl+Shift+Down"
+        onTriggered: {
+          appSettings.windowOpacity += appSettings.windowOpacity < (2 - keybindStep) ? keybindStep : 0
+        }
     }
     Action {
         id: showAboutAction

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -147,6 +147,22 @@ ApplicationWindow {
         }
     }
     Action {
+        id: moreContrast
+        text: qsTr("More contrast.")
+        shortcut: "Ctrl+Up"
+        onTriggered: {
+          appSettings.contrast += appSettings.contrast < (1 - keybindStep) ? keybindStep : 0
+        }
+    }
+    Action {
+        id: lessContrast
+        text: qsTr("Less contrast.")
+        shortcut: "Ctrl+Down"
+        onTriggered: {
+          appSettings.contrast -= appSettings.contrast > keybindStep ? keybindStep : 0
+        }
+    }
+    Action {
         id: showAboutAction
         text: qsTr("About")
         onTriggered: {

--- a/app/qml/main.qml
+++ b/app/qml/main.qml
@@ -29,7 +29,7 @@ ApplicationWindow {
     width: 1024
     height: 768
 
-    property real keybindStep: 0.005
+    property real keybindStep: 0.01
 
     // Save window properties automatically
     onXChanged: appSettings.x = x
@@ -143,7 +143,7 @@ ApplicationWindow {
         text: qsTr("Make more opaque.")
         shortcut: "Ctrl+Shift+Down"
         onTriggered: {
-          appSettings.windowOpacity += appSettings.windowOpacity < (2 - keybindStep) ? keybindStep : 0
+          appSettings.windowOpacity += appSettings.windowOpacity < (1 - keybindStep) ? keybindStep : 0
         }
     }
     Action {


### PR DESCRIPTION
User is now able to change these settings by their key binds:

Tansparency: (more): Ctrl+Shift+Up and (less): Ctrl+Shift+Down**
Contrast: (more): Ctrl+Up and (less): Ctrl+Down.
Brightness: (more): Alt+Up and (less): Alt+Down.

- **Added transparency keybind, fixed on Ctrl+Shift+Up and Ctrl+Shift+Down**
- **Steeper step and max correction.**
- **Contrast bind set to Ctrl+Up, Ctrl+Down.**
- **Alt+Up for brighter, Alt+Down for darker.**
