### PR TITLE
Add checkbox to settings for terminal size overlay

### DIFF
--- a/app/qml/SettingsTerminalTab.qml
+++ b/app/qml/SettingsTerminalTab.qml
@@ -114,7 +114,7 @@ ColumnLayout {
         }
     }
     GroupBox {
-        title: qsTr("Cursor")
+        title: qsTr("Behavior")
         Layout.fillWidth: true
         ColumnLayout {
             anchors.fill: parent
@@ -128,6 +128,17 @@ ColumnLayout {
                 target: blinkingCursor
                 property: "checked"
                 value: appSettings.blinkingCursor
+            }
+            CheckBox {
+                id: showTerminalSize
+                text: qsTr("Show dimensions on resize")
+                checked: appSettings.showTerminalSize
+                onCheckedChanged: appSettings.showTerminalSize = checked
+            }
+            Binding {
+                target: showTerminalSize
+                property: "checked"
+                value: appSettings.showTerminalSize
             }
         }
     }


### PR DESCRIPTION
As requested in #554.

Looks like this was already on the way to being implemented, just missing the checkbox.