### PR TITLE
bugfix: add missing background color setting for Settings window

### DIFF
--- a/app/qml/SettingsWindow.qml
+++ b/app/qml/SettingsWindow.qml
@@ -29,6 +29,7 @@ Window {
     title: qsTr("Settings")
     width: 640
     height: 640
+    color: palette.base
 
     property int tabmargins: 15
 


### PR DESCRIPTION
Closes: #637, #746, #826, #841, #885