### PR TITLE
bugfix: replace hardcoded static frame color white

### DIFF
--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -35,6 +35,7 @@ QtObject {
     readonly property real maxBurnInFadeTime: 1600
 
     property bool isMacOS: Qt.platform.os === "osx"
+    property bool runsOnDarkDesktopTheme: (0.299 * palette.base.r + 0.587 * palette.base.g + 0.114 * palette.base.b) < 0.5
 
     // GENERAL SETTINGS ///////////////////////////////////////////////////////
     property int x: 100

--- a/app/qml/ShaderTerminal.qml
+++ b/app/qml/ShaderTerminal.qml
@@ -358,6 +358,7 @@ Item {
                  id: terminalFrame
                  blending: false
                  anchors.fill: parent
+                 runsOnDarkDesktopTheme: appSettings.runsOnDarkDesktopTheme
              }
          }
      }

--- a/app/qml/TerminalFrame.qml
+++ b/app/qml/TerminalFrame.qml
@@ -22,13 +22,15 @@ import QtQuick 2.0
 import "utils.js" as Utils
 
 ShaderEffect {
-    property color _staticFrameColor: "#fff"
+    property bool runsOnDarkDesktopTheme: false
+
+    property color _staticFrameColor: runsOnDarkDesktopTheme ? "black" : "white"
     property color _backgroundColor: appSettings.backgroundColor
     property color _fontColor: appSettings.fontColor
     property color _lightColor: Utils.mix(_fontColor, _backgroundColor, 0.2)
     property real _ambientLight: Utils.lint(0.2, 0.8, appSettings.ambientLight)
 
-    property color frameColor: Utils.mix(_staticFrameColor, _lightColor, _ambientLight)
+    property color frameColor: runsOnDarkDesktopTheme ? "black" : Utils.mix(_staticFrameColor, _lightColor, _ambientLight)
     property real screenCurvature: appSettings.screenCurvature * appSettings.screenCurvatureSize
 
     // Coefficient of the log curve used to approximate shadowing


### PR DESCRIPTION
bugfix: replace hardcoded static frame color white
by dynamic calculation (white or black),
depending on the currently active desktop theme (light or dark)

Closes: #781, #889