### PR TITLE
Use working directory instead of home directory by default

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -4,6 +4,8 @@
 #include <QQmlContext>
 #include <QStringList>
 
+#include <QDir>
+
 #include <QtWidgets/QApplication>
 #include <QIcon>
 #include <QQuickStyle>
@@ -125,7 +127,7 @@ int main(int argc, char *argv[])
     engine.rootContext()->setContextProperty("defaultCmd", command);
     engine.rootContext()->setContextProperty("defaultCmdArgs", commandArgs);
 
-    engine.rootContext()->setContextProperty("workdir", getNamedArgument(args, "--workdir", "$HOME"));
+    engine.rootContext()->setContextProperty("workdir", getNamedArgument(args, "--workdir", QDir::currentPath()));
     engine.rootContext()->setContextProperty("fileIO", &fileIO);
 
     // Manage import paths for Linux and OSX.


### PR DESCRIPTION
This change makes Cool Retro Term use the current working directory by default, instead of the home directory. This allows the program to integrate with file explorers which use contextual working directories to launch terminals at certain paths. It also allows the program to be launched from other terminals while keeping the active working directory.