### PR TITLE
Baud rate feature

### DIFF
--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -101,6 +101,10 @@ QtObject {
 
     readonly property bool frameEnabled: ambientLight > 0 || _frameSize > 0 || screenCurvature > 0
 
+    // BAUD RATE SETTINGS /////////////////////////////////////////////////////
+    property int baudRate: 0  // 0 = off, otherwise bits-per-second
+    property string baudRateMode: "off"  // "off", "display-aesthetic", "input-aesthetic", "both-aesthetic", etc.
+
     readonly property int no_rasterization: 0
     readonly property int scanline_rasterization: 1
     readonly property int pixel_rasterization: 2
@@ -200,7 +204,9 @@ QtObject {
             "frameSize": _frameSize,
             "screenRadius": _screenRadius,
             "frameColor": _frameColor,
-            "frameShininess": _frameShininess
+            "frameShininess": _frameShininess,
+            "baudRate": baudRate,
+            "baudRateMode": baudRateMode
         }
         return profile
     }
@@ -308,6 +314,10 @@ QtObject {
         _frameShininess = settings.frameShininess !== undefined ? settings.frameShininess : _frameShininess
 
         blinkingCursor = settings.blinkingCursor !== undefined ? settings.blinkingCursor : blinkingCursor
+
+        // Load baud rate settings
+        baudRate = settings.baudRate !== undefined ? settings.baudRate : baudRate
+        baudRateMode = settings.baudRateMode !== undefined ? settings.baudRateMode : baudRateMode
     }
 
     function storeCustomProfiles() {

--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -315,7 +315,6 @@ QtObject {
 
         blinkingCursor = settings.blinkingCursor !== undefined ? settings.blinkingCursor : blinkingCursor
 
-        // Load baud rate settings
         baudRate = settings.baudRate !== undefined ? settings.baudRate : baudRate
         baudRateMode = settings.baudRateMode !== undefined ? settings.baudRateMode : baudRateMode
     }

--- a/app/qml/PreprocessedTerminal.qml
+++ b/app/qml/PreprocessedTerminal.qml
@@ -122,6 +122,9 @@ Item{
         session: QMLTermSession {
             id: ksession
 
+            baudRate: appSettings.baudRate
+            baudRateMode: appSettings.baudRateMode
+
             onFinished: {
                 terminalContainer.sessionFinished()
             }

--- a/app/qml/SettingsTerminalTab.qml
+++ b/app/qml/SettingsTerminalTab.qml
@@ -219,4 +219,106 @@ ColumnLayout {
             }
         }
     }
+    GroupBox {
+        title: qsTr("Baud Rate")
+        Layout.fillWidth: true
+        Layout.fillHeight: false
+        padding: appSettings.defaultMargin
+        ColumnLayout {
+            anchors.fill: parent
+            RowLayout {
+                Layout.fillWidth: true
+                Label {
+                    text: qsTr("Rate (bps)")
+                }
+                ComboBox {
+                    id: baudRateCombo
+                    Layout.fillWidth: true
+                    model: ["Off", "300", "1200", "2400", "4800", "9600", "19200", "38400", "Custom"]
+                    currentIndex: {
+                        switch(appSettings.baudRate) {
+                            case 0: return 0
+                            case 300: return 1
+                            case 1200: return 2
+                            case 2400: return 3
+                            case 4800: return 4
+                            case 9600: return 5
+                            case 19200: return 6
+                            case 38400: return 7
+                            default: return 8
+                        }
+                    }
+                    onActivated: {
+                        switch(currentIndex) {
+                            case 0: appSettings.baudRate = 0; break
+                            case 1: appSettings.baudRate = 300; break
+                            case 2: appSettings.baudRate = 1200; break
+                            case 3: appSettings.baudRate = 2400; break
+                            case 4: appSettings.baudRate = 4800; break
+                            case 5: appSettings.baudRate = 9600; break
+                            case 6: appSettings.baudRate = 19200; break
+                            case 7: appSettings.baudRate = 38400; break
+                            case 8: break // Custom - use text field
+                        }
+                    }
+                }
+                TextField {
+                    visible: baudRateCombo.currentIndex === 8
+                    placeholderText: "3000"
+                    Layout.preferredWidth: 80
+                    onTextChanged: {
+                        var val = parseInt(text)
+                        if (!isNaN(val) && val > 0) {
+                            appSettings.baudRate = val
+                        }
+                    }
+                    Component.onCompleted: {
+                        text = appSettings.baudRate.toString()
+                    }
+                    Connections {
+                        target: appSettings
+                        onBaudRateChanged: {
+                            if (baudRateCombo.currentIndex === 8 && text !== appSettings.baudRate.toString()) {
+                                text = appSettings.baudRate.toString()
+                            }
+                        }
+                    }
+                }
+            }
+            ColumnLayout {
+                Layout.fillWidth: true
+                Label {
+                    text: qsTr("Mode")
+                    font.bold: true
+                }
+                RadioButton {
+                    text: qsTr("Off - No delay")
+                    checked: appSettings.baudRateMode === "off"
+                    onClicked: appSettings.baudRateMode = "off"
+                }
+                RadioButton {
+                    text: qsTr("Visual Only - Display (text appears slowly)")
+                    checked: appSettings.baudRateMode === "display-aesthetic"
+                    onClicked: appSettings.baudRateMode = "display-aesthetic"
+                }
+                RadioButton {
+                    text: qsTr("Visual Only - Input (typing echoed slowly)")
+                    checked: appSettings.baudRateMode === "input-aesthetic"
+                    onClicked: appSettings.baudRateMode = "input-aesthetic"
+                }
+                RadioButton {
+                    text: qsTr("Visual Only - Both (display and input delayed)")
+                    checked: appSettings.baudRateMode === "both-aesthetic"
+                    onClicked: appSettings.baudRateMode = "both-aesthetic"
+                }
+            }
+            Label {
+                text: qsTr("Visual Only modes create display delays without affecting actual I/O responsiveness. Authentic PTY modes (coming soon) would throttle actual keystroke registration and data rates.")
+                wrapMode: Text.WordWrap
+                font.pixelSize: 10
+                color: "#888888"
+                Layout.fillWidth: true
+            }
+        }
+    }
 }

--- a/app/qml/SettingsTerminalTab.qml
+++ b/app/qml/SettingsTerminalTab.qml
@@ -24,11 +24,18 @@ import QtQml 2.0
 
 import "Components"
 
-ColumnLayout {
-    GroupBox {
-        title: qsTr("Font")
-        Layout.fillWidth: true
-        Layout.fillHeight: true
+ScrollView {
+    Layout.fillWidth: true
+    Layout.fillHeight: true
+    contentWidth: availableWidth
+    clip: true
+
+    ColumnLayout {
+        width: parent.width
+
+        GroupBox {
+            title: qsTr("Font")
+            Layout.fillWidth: true
         padding: appSettings.defaultMargin
         GridLayout {
             anchors.fill: parent
@@ -172,10 +179,9 @@ ColumnLayout {
             }
         }
     }
-    GroupBox {
-        title: qsTr("Colors")
-        Layout.fillWidth: true
-        Layout.fillHeight: true
+        GroupBox {
+            title: qsTr("Colors")
+            Layout.fillWidth: true
         padding: appSettings.defaultMargin
         ColumnLayout {
             anchors.fill: parent
@@ -219,10 +225,9 @@ ColumnLayout {
             }
         }
     }
-    GroupBox {
-        title: qsTr("Baud Rate")
-        Layout.fillWidth: true
-        Layout.fillHeight: false
+        GroupBox {
+            title: qsTr("Baud Rate")
+            Layout.fillWidth: true
         padding: appSettings.defaultMargin
         ColumnLayout {
             anchors.fill: parent
@@ -297,28 +302,29 @@ ColumnLayout {
                     onClicked: appSettings.baudRateMode = "off"
                 }
                 RadioButton {
-                    text: qsTr("Visual Only - Display (text appears slowly)")
+                    text: qsTr("Display (text appears slowly)")
                     checked: appSettings.baudRateMode === "display-aesthetic"
                     onClicked: appSettings.baudRateMode = "display-aesthetic"
                 }
                 RadioButton {
-                    text: qsTr("Visual Only - Input (typing echoed slowly)")
+                    text: qsTr("Input (typing echoed slowly)")
                     checked: appSettings.baudRateMode === "input-aesthetic"
                     onClicked: appSettings.baudRateMode = "input-aesthetic"
                 }
                 RadioButton {
-                    text: qsTr("Visual Only - Both (display and input delayed)")
+                    text: qsTr("Both (display and input delayed)")
                     checked: appSettings.baudRateMode === "both-aesthetic"
                     onClicked: appSettings.baudRateMode = "both-aesthetic"
                 }
             }
             Label {
-                text: qsTr("Visual Only modes create display delays without affecting actual I/O responsiveness. Authentic PTY modes (coming soon) would throttle actual keystroke registration and data rates.")
+                text: qsTr("Aesthetic baud-rate limits create display delays without affecting actual I/O responsiveness. This is not an authentic PTY mode, which would throttle actual keystroke registration and data rates.")
                 wrapMode: Text.WordWrap
                 font.pixelSize: 10
                 color: "#888888"
                 Layout.fillWidth: true
             }
+        }
         }
     }
 }


### PR DESCRIPTION
This feature along with code in qmltermwidget allows for users to simulate slow terminal baud rates.  This does not affect all processes communicating with the TTY / PTY, but only reading and writing characters to the terminal making this an aesthetic change only.

Configuration options were added to the terminal settings tab, along with a minor adjustment to the height grouping to allow for scrolling the config options, since the options do not fit within the original static window size any longer.