### PR TITLE
Fix burn-in effect triggering redundant GPU shader passes

### DIFF
--- a/app/qml/BurnInEffect.qml
+++ b/app/qml/BurnInEffect.qml
@@ -44,9 +44,8 @@ Loader {
         if (newTime > lastUpdate) {
             prevLastUpdate = lastUpdate
             lastUpdate = newTime
+            item.source.scheduleUpdate()
         }
-
-        item.source.scheduleUpdate()
     }
 
     function restartBlurSource() {

--- a/app/qml/BurnInEffect.qml
+++ b/app/qml/BurnInEffect.qml
@@ -51,7 +51,7 @@ Loader {
     function restartBlurSource() {
         prevLastUpdate = timeManager.time
         lastUpdate = prevLastUpdate
-        completelyUpdate()
+        item.source.scheduleUpdate()
     }
 
     sourceComponent: Item {


### PR DESCRIPTION
Hey! Been a daily user and love the project.

I've been investigating the progressive input lag reported in #816, #483 and #235. This PR fixes the highest-impact cause on the cool-retro-term side, while a companion PR ([qmltermwidget#50](https://github.com/Swordfish90/qmltermwidget/pull/50)) addresses the terminal backend side.

## Problem

In `BurnInEffect.qml`, the `completelyUpdate()` function calls `item.source.scheduleUpdate()` **unconditionally** — even when `timeManager.time` hasn't changed:

```qml
function completelyUpdate() {
    let newTime = timeManager.time
    if (newTime > lastUpdate) {
        prevLastUpdate = lastUpdate
        lastUpdate = newTime
    }
    // ← always runs, even when time didn't change
    item.source.scheduleUpdate()
}
```

This means the **recursive** `ShaderEffectSource` (the most expensive GPU operation in the rendering pipeline) is re-rendered on every `imagePainted` signal, including:

- **Cursor blinks** every 500ms (`blinkCursorEvent` → `updateCursor` → `update(cursorRect)` → `imagePainted`)
- **Every frame** regardless of `effectsFrameSkip` setting

With the default `effectsFrameSkip=3`, `timeManager.time` only updates every 3rd frame. During the 2 skipped frames, the burn-in shader produces identical output (same `time` → same fade calculation), so the GPU work is entirely wasted.

## Fix

Two changes:

**1.** Move `scheduleUpdate()` inside the conditional in `completelyUpdate()`:

```qml
function completelyUpdate() {
    let newTime = timeManager.time
    if (newTime > lastUpdate) {
        prevLastUpdate = lastUpdate
        lastUpdate = newTime
        item.source.scheduleUpdate()  // only when time actually changed
    }
}
```

**2.** Update `restartBlurSource()` to call `scheduleUpdate()` directly (since `completelyUpdate()` would now skip the update after resetting `lastUpdate` to current time):

```qml
function restartBlurSource() {
    prevLastUpdate = timeManager.time
    lastUpdate = prevLastUpdate
    item.source.scheduleUpdate()  // force immediate update on settings change
}
```

## Impact

- **~67% reduction in burn-in GPU shader work** at default settings (skip 2 of every 3 frames)
- Cursor-only blinks no longer force full shader re-render during skipped frames
- The burn-in visual effect is fully preserved — updates still happen whenever `timeManager.time` advances
- Settings changes (font, burn-in quality, rasterization) still take effect immediately via `restartBlurSource()`

## Testing

- Built and tested on macOS arm64, Qt 6.11.0
- Verified all effects work: burn-in persistence, bloom, scanlines, flickering, curvature
- Burn-in ghosting appears and fades correctly when typing
- Changing burn-in settings (quality, intensity) takes effect immediately
- Rapid typing, scrolling, window resize — all work normally

## Companion PR

The terminal backend optimizations (per-frame heap allocations, QFontMetrics caching) are in a separate PR to qmltermwidget: https://github.com/Swordfish90/qmltermwidget/pull/50

Together, these changes address the root causes of progressive input lag that several users have reported.

## Related issues

- #816 — Graphics update rate slowly drops over time
- #483 — Keystroke → output delay
- #235 — Improving performance