### PR TITLE
Add missing lineSpacing setting to composeProfileObject()

### DIFF
--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -195,6 +195,7 @@ QtObject {
             "fontName": fontName,
             "fontSource": fontSource,
             "fontWidth": fontWidth,
+            "lineSpacing": lineSpacing,
             "margin": _margin,
             "blinkingCursor": blinkingCursor,
             "frameSize": _frameSize,


### PR DESCRIPTION
The lineSpacing setting is not persisted (neither custom or current profile), this one line fixes that.