### PR TITLE
Fix loading System font from current & custom profiles

### DIFF
--- a/app/qml/ApplicationSettings.qml
+++ b/app/qml/ApplicationSettings.qml
@@ -296,8 +296,8 @@ QtObject {
         windowOpacity = settings.windowOpacity
                 !== undefined ? settings.windowOpacity : windowOpacity
 
-        fontName = settings.fontName !== undefined ? settings.fontName : fontName
         fontSource = settings.fontSource !== undefined ? settings.fontSource : fontSource
+        fontName = settings.fontName !== undefined ? settings.fontName : fontName
         fontWidth = settings.fontWidth !== undefined ? settings.fontWidth : fontWidth
         lineSpacing = settings.lineSpacing !== undefined ? settings.lineSpacing : lineSpacing
 


### PR DESCRIPTION
When fontName is loaded before fontSource, fontSource is still set to the default 'Bundled', thus the stored fontName is not found and it defaults to the first in the list of 'Bundled' fonts. After that the correct fontSource 'System' is loaded, but the fontName is not loaded from persistence anymore.

Fix: switch the two statements to first load fontSource and then fontName.