### PR TITLE
Fix qmake shader output path

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -42,7 +42,7 @@ SHADERS -= $$SHADERS_DIR/terminal_static.frag
 SHADERS -= $$SHADERS_DIR/passthrough.vert
 
 qsb.input = SHADERS
-qsb.output = ../../app/shaders/${QMAKE_FILE_NAME}.qsb
+qsb.output = $$relative_path($$SHADERS_DIR, $$OUT_PWD)/${QMAKE_FILE_BASE}${QMAKE_FILE_EXT}.qsb
 qsb.commands = $$QSB_BIN --glsl \"100 es,120,150\" --hlsl 50 --msl 12 --qt6 -o ${QMAKE_FILE_OUT} ${QMAKE_FILE_IN}
 qsb.clean = $$qsb.output
 qsb.name = qsb ${QMAKE_FILE_IN}


### PR DESCRIPTION
Fixed qmake shader baker output paths so generated `.qsb` files stay under `app/shaders`. This prevents qmake from creating a stray `../app/shaders/shaders` directory outside the repository.

# Verification
- Regenerated `app/Makefile` and confirmed qsb targets no longer reference `../../app/shaders`.
- Removed the stray parent `app` directory and ran `make -j8`.
- Confirmed the parent `app` directory was not recreated.