### PR TITLE
Bind settings and dialog windows to the active palette

### DIFF
--- a/app/qml/AboutDialog.qml
+++ b/app/qml/AboutDialog.qml
@@ -28,6 +28,10 @@ ApplicationWindow {
     width: 600
     height: 400
 
+    // Follow the active palette so the dialog isn't white on dark themes.
+    // See issues #847, #689.
+    color: palette.window
+
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 15

--- a/app/qml/InsertNameDialog.qml
+++ b/app/qml/InsertNameDialog.qml
@@ -30,6 +30,10 @@ Window {
     modality: Qt.ApplicationModal
     title: qsTr("Save new profile")
 
+    // Follow the active palette; a bare Window defaults to white otherwise,
+    // leaving this dialog unreadable on dark themes. See issues #847, #689.
+    color: palette.window
+
     property alias profileName: namefield.text
     signal nameSelected(string name)
 

--- a/app/qml/SettingsWindow.qml
+++ b/app/qml/SettingsWindow.qml
@@ -32,6 +32,12 @@ ApplicationWindow {
     width: 640
     height: 520
 
+    // Follow the active palette so the window background matches the rest of
+    // the desktop. Without this an ApplicationWindow inherits the Controls
+    // style default (white on the Basic style), making the settings unreadable
+    // on dark themes. See issues #847, #689.
+    color: palette.window
+
     Item {
         anchors { fill: parent; }
 


### PR DESCRIPTION
Bind settings window background to the active palette

The settings ApplicationWindow never set a background color, so it
inherited the QtQuick Controls style default (white with the Basic
style). On dark desktops the controls render light-on-light and the
settings panel is unreadable.

Binding color to palette.window makes the window follow whatever
palette the rest of the app/desktop uses -- dark on dark themes,
light on light -- instead of a hardcoded default.

Fixes #847, #689.


Bind remaining dialog windows to the active palette

The Save-new-profile (InsertNameDialog) and About windows had the same
missing-background issue as the settings window: a bare Window /
ApplicationWindow with no color, defaulting to white and unreadable on
dark themes.

Same fix as the settings window -- color: palette.window.

Fixes #847, #689.