### PR TITLE
Fix garbled rendering when a screen's scale factor changes

### DIFF
--- a/app/qml/PreprocessedTerminal.qml
+++ b/app/qml/PreprocessedTerminal.qml
@@ -96,7 +96,7 @@ Item{
     QMLTermWidget {
         id: kterminal
 
-        property int textureResolutionScale: appSettings.lowResolutionFont ? Screen.devicePixelRatio : 1
+        property int textureResolutionScale: appSettings.lowResolutionFont ? terminalWindow.screenDevicePixelRatio : 1
         property int margin: appSettings.margin / screenScaling
         property int totalWidth: Math.floor(parent.width / (screenScaling * fontWidth))
         property int totalHeight: Math.floor(parent.height / screenScaling)
@@ -106,8 +106,8 @@ Item{
 
         textureSize: Qt.size(width / textureResolutionScale, height / textureResolutionScale)
 
-        width: ensureMultiple(rawWidth, Screen.devicePixelRatio)
-        height: ensureMultiple(rawHeight, Screen.devicePixelRatio)
+        width: ensureMultiple(rawWidth, terminalWindow.screenDevicePixelRatio)
+        height: ensureMultiple(rawHeight, terminalWindow.screenDevicePixelRatio)
 
         /** Ensure size is a multiple of factor. This is needed for pixel perfect scaling on highdpi screens. */
         function ensureMultiple(size, factor) {

--- a/app/qml/TerminalContainer.qml
+++ b/app/qml/TerminalContainer.qml
@@ -37,8 +37,8 @@ ShaderTerminal {
     burnInEffect: terminal.burnInEffect
     virtualResolution: terminal.virtualResolution
     screenResolution: Qt.size(
-        terminalWindow.width * Screen.devicePixelRatio * appSettings.windowScaling,
-        terminalWindow.height * Screen.devicePixelRatio * appSettings.windowScaling
+        terminalWindow.width * terminalWindow.screenDevicePixelRatio * appSettings.windowScaling,
+        terminalWindow.height * terminalWindow.screenDevicePixelRatio * appSettings.windowScaling
     )
     bloomSource: bloomSourceLoader.item
 

--- a/app/qml/TerminalWindow.qml
+++ b/app/qml/TerminalWindow.qml
@@ -29,8 +29,20 @@ ApplicationWindow {
     width: 1024
     height: 768
 
+    // The scale factor of the screen this window is on, kept in a property of our
+    // own. Screen.devicePixelRatio reads the current value but carries no working
+    // change notification, so a binding on it keeps the ratio the window was built
+    // with and every size derived from it is left behind when the scale changes.
+    // The screen's other measures do notify, and any change of scale or of screen
+    // moves at least one of them, so they are the cue to read the ratio again.
+    property real screenDevicePixelRatio: 1
+    readonly property string screenState:
+        Screen.name + " " + Screen.width + "x" + Screen.height + "@" + Screen.pixelDensity
+    onScreenStateChanged: screenDevicePixelRatio = Screen.devicePixelRatio
+
     // Show the window once it is ready.
     Component.onCompleted: {
+        screenDevicePixelRatio = Screen.devicePixelRatio
         visible = true
     }
 


### PR DESCRIPTION
Fixes #541.

What's going on is in my comment on that issue, with the logging output: https://github.com/Swordfish90/cool-retro-term/issues/541#issuecomment-5260907866

Short version. Three bindings size the terminal's offscreen texture from `Screen.devicePixelRatio`: `textureResolutionScale`, the `ensureMultiple()` rounding of the widget's width and height, and the `screenResolution` handed to the shader. That property doesn't fire its change notification when a screen's scale factor moves under a live window, so none of them re-run. The texture stays sized for whatever the ratio was when the window was built. Drop from 2 to 1 and the terminal keeps drawing into a half-size texture that then gets blown up to fill the screen.

This keeps the ratio on the window and reads it again when the screen's name, size or pixel density moves, since those do notify. The three call sites bind to that.

Three files, 17 lines added, 5 changed. No new files, and the shader chain is left alone.

Tested on GNOME Wayland, flipping between a 2880x1800 panel at scale 2 and a mirrored 1920x1080 pair at scale 1. `textureResolutionScale` follows the ratio both ways and goes back to 2 on the way back. Before, it held the startup value for the life of the window.

#541 is a macOS report and I can't test there. The property and its notification are QML, not platform code, so I'd expect the same behaviour, but I haven't confirmed it.

<img width="1056" height="520" alt="verdict" src="https://github.com/user-attachments/assets/c7baff43-fbd4-4c56-ad31-c389ff94e192" />
